### PR TITLE
feat(tui): quick allow/block from the query log + fix sidebar icon widths

### DIFF
--- a/internal/tui/core/nav.go
+++ b/internal/tui/core/nav.go
@@ -30,15 +30,20 @@ type PageMeta struct {
 
 // pageOrder is the canonical sidebar order.
 var pageOrder = []PageMeta{
+	// Icons must be single display-width glyphs. Emoji-presentation symbols
+	// (Misc Symbols block U+2600–26FF: ⛒ ⛃ ⚙ ☰ …) render as 2 cells in most
+	// terminals while runewidth counts them as 1, which knocks every label
+	// out of alignment.
+	// Stick to BMP math/geometric symbols, which are reliably one cell wide.
 	{PageDashboard, "Dashboard", "▤"},
 	{PageBlocking, "Blocking", "⦸"},
 	{PageQueryLog, "Query Log", "≡"},
-	{PageDomains, "Domains", "⛒"},
-	{PageGroups, "Groups", "⛃"},
+	{PageDomains, "Domains", "⊗"},
+	{PageGroups, "Groups", "⧉"},
 	{PageClients, "Clients", "⌂"},
-	{PageAdlists, "Adlists", "☰"},
+	{PageAdlists, "Adlists", "≣"},
 	{PageLocalDNS, "Local DNS", "◈"},
-	{PageSettings, "Settings", "⚙"},
+	{PageSettings, "Settings", "⊙"},
 	{PageSystem, "System", "❖"},
 }
 

--- a/internal/tui/screens/querylog/querylog.go
+++ b/internal/tui/screens/querylog/querylog.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/zackkitzmiller/tihole/internal/pihole"
 	"github.com/zackkitzmiller/tihole/internal/theme"
+	"github.com/zackkitzmiller/tihole/internal/tui/components"
 	"github.com/zackkitzmiller/tihole/internal/tui/core"
 )
 
@@ -40,6 +41,24 @@ type queriesMsg struct {
 	err   error
 }
 
+// classifyMsg reports the result of a quick allow/block. verb is the past-tense
+// label for the success toast ("allowed"/"blocked").
+type classifyMsg struct {
+	domain string
+	verb   string
+	err    error
+}
+
+// noteExpireMsg clears the transient success toast.
+type noteExpireMsg struct{}
+
+// noteTTL is how long a quick-classify success toast stays on screen.
+const noteTTL = 4 * time.Second
+
+// classifyComment tags entries added from the query log so their origin is
+// obvious in the Domains screen.
+const classifyComment = "added from query log (tihole)"
+
 // Model is the query-log screen.
 type Model struct {
 	ctx *core.AppContext
@@ -52,6 +71,12 @@ type Model struct {
 
 	queries []pihole.Query // raw rows, parallel to the table
 	detail  *pihole.Query  // non-nil while the detail pane is open
+
+	// Quick-classify: allow/block the selected domain straight from the log.
+	confirm       components.ConfirmDialog
+	pendingType   pihole.DomainType // allow/deny awaiting confirmation
+	pendingDomain string            // the domain awaiting confirmation
+	note          string            // transient success toast (e.g. "allowed x")
 
 	filterDomain string
 	filtered     int
@@ -96,9 +121,11 @@ func (m *Model) Init() tea.Cmd { return nil }
 // Title is shown in the header/status bar.
 func (m *Model) Title() string { return "Query Log" }
 
-// CapturesInput reports whether the search field is focused, so the root
-// delivers raw keys instead of firing global shortcuts (see core.InputCapturer).
-func (m *Model) CapturesInput() bool { return m.searching }
+// CapturesInput reports whether the screen wants raw keys instead of the root's
+// global single-key shortcuts (see core.InputCapturer): while the search field
+// is focused, or while the quick-classify confirm is up so y/n/esc stay local
+// rather than firing d=toggle-block or the esc-to-rail climb.
+func (m *Model) CapturesInput() bool { return m.searching || m.confirm.Active }
 
 // Focus activates the screen: start the poller and fetch a fresh page.
 func (m *Model) Focus() tea.Cmd {
@@ -125,6 +152,8 @@ func (m *Model) Help() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
 		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "detail")),
+		key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "allow")),
+		key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "block")),
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "close")),
 	}
 }
@@ -202,6 +231,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncRows()
 		return m, nil
 
+	case classifyMsg:
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.err = nil
+		m.note = msg.verb + " " + msg.domain
+		return m, m.expireNote()
+
+	case noteExpireMsg:
+		m.note = ""
+		return m, nil
+
 	case spinner.TickMsg:
 		if !m.loading {
 			return m, nil
@@ -215,6 +257,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// expireNote schedules the success toast to clear after noteTTL.
+func (m *Model) expireNote() tea.Cmd {
+	return tea.Tick(noteTTL, func(time.Time) tea.Msg { return noteExpireMsg{} })
 }
 
 // handleKey routes keystrokes through the search box, detail pane, and table.
@@ -238,6 +285,18 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.search, cmd = m.search.Update(msg)
 		return m, cmd
+	}
+
+	if m.confirm.Active {
+		return m.handleConfirmKey(msg)
+	}
+
+	// Quick-classify works from both the table and the detail pane.
+	switch msg.String() {
+	case "a":
+		return m.promptClassify(pihole.DomainAllow)
+	case "b":
+		return m.promptClassify(pihole.DomainDeny)
 	}
 
 	if m.detail != nil {
@@ -265,6 +324,73 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.table, cmd = m.table.Update(msg)
 	return m, cmd
+}
+
+// selectedDomain resolves the domain the quick actions target: the detail
+// pane's domain when it's open, otherwise the highlighted table row.
+func (m *Model) selectedDomain() (string, bool) {
+	if m.detail != nil {
+		d := strings.TrimSpace(m.detail.Domain)
+		return d, d != ""
+	}
+	idx := m.table.Cursor()
+	if idx >= 0 && idx < len(m.queries) {
+		d := strings.TrimSpace(m.queries[idx].Domain)
+		return d, d != ""
+	}
+	return "", false
+}
+
+// promptClassify opens the confirm dialog for allowing/blocking the selected
+// domain. A blank selection is a no-op.
+func (m *Model) promptClassify(dt pihole.DomainType) (tea.Model, tea.Cmd) {
+	domain, ok := m.selectedDomain()
+	if !ok {
+		return m, nil
+	}
+	m.pendingType = dt
+	m.pendingDomain = domain
+
+	title, danger := "Allow domain?", false
+	if dt == pihole.DomainDeny {
+		title, danger = "Block domain?", true
+	}
+	m.confirm = m.confirm.Show(title, domain, danger)
+	return m, nil
+}
+
+// handleConfirmKey interprets y/n on the quick-classify confirmation.
+func (m *Model) handleConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "enter":
+		dt, domain := m.pendingType, m.pendingDomain
+		m.confirm = m.confirm.Hide()
+		m.pendingDomain = ""
+		if domain == "" {
+			return m, nil
+		}
+		return m, m.classify(dt, domain)
+	case "n", "esc":
+		m.confirm = m.confirm.Hide()
+		m.pendingDomain = ""
+	}
+	return m, nil
+}
+
+// classify dispatches the allow/deny add as an exact-match domain. It runs on a
+// self-contained context so it never disturbs the live poll's cancel handle.
+func (m *Model) classify(dt pihole.DomainType, domain string) tea.Cmd {
+	api := m.ctx.API
+	verb := "allowed"
+	if dt == pihole.DomainDeny {
+		verb = "blocked"
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+		defer cancel()
+		_, err := api.AddDomain(ctx, dt, pihole.KindExact, domain, classifyComment, nil)
+		return classifyMsg{domain: domain, verb: verb, err: err}
+	}
 }
 
 // syncRows rebuilds the table rows from the current queries and theme,
@@ -327,10 +453,13 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	line := left + strings.Repeat(" ", gap) + count
 
 	searchLine := ""
-	if m.searching {
+	switch {
+	case m.searching:
 		searchLine = m.search.View()
-	} else if m.err != nil {
+	case m.err != nil:
 		searchLine = m.errBanner(th)
+	case m.note != "":
+		searchLine = th.AllowStyle().Bold(true).Render(truncate("✓ "+m.note, maxInt(m.w-2, 8)))
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, line, searchLine)
 }
@@ -344,6 +473,10 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	bodyH := m.h - headerHeight - footerHeight
 	if bodyH < 1 {
 		bodyH = 1
+	}
+
+	if m.confirm.Active {
+		return m.confirm.Render(th, m.w, bodyH)
 	}
 
 	if m.detail != nil {
@@ -404,7 +537,7 @@ func (m *Model) renderDetail(th *theme.Theme, bodyH int) string {
 }
 
 func (m *Model) renderFooter(th *theme.Theme) string {
-	hint := "↑↓ navigate · / search · enter detail · esc close"
+	hint := "↑↓ navigate · / search · enter detail · a allow · b block · esc close"
 	return th.SubtleStyle().Render(truncate(hint, maxInt(m.w, 8)))
 }
 

--- a/internal/tui/screens/querylog/querylog_view_test.go
+++ b/internal/tui/screens/querylog/querylog_view_test.go
@@ -75,8 +75,8 @@ func TestTitleIsQueryLog(t *testing.T) {
 }
 
 func TestHelpReturnsBindings(t *testing.T) {
-	if got := len(newModel().Help()); got != 3 {
-		t.Fatalf("expected 3 help bindings, got %d", got)
+	if got := len(newModel().Help()); got != 5 {
+		t.Fatalf("expected 5 help bindings, got %d", got)
 	}
 }
 

--- a/internal/tui/screens/querylog/quickclassify_test.go
+++ b/internal/tui/screens/querylog/quickclassify_test.go
@@ -1,0 +1,199 @@
+package querylog
+
+import (
+	"testing"
+
+	"github.com/zackkitzmiller/tihole/internal/pihole"
+)
+
+// modelWithQuery returns a focused, panel-ready model with one query row so the
+// cursor resolves to a real domain.
+func modelWithQuery(domain string) *Model {
+	m := newTestModel()
+	m.SetSize(100, 24)
+	m.focused = true
+	m.queries = []pihole.Query{{Domain: domain, Status: "GRAVITY"}}
+	m.syncRows()
+	return m
+}
+
+func TestPressingAllowOpensConfirm(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+
+	// Act
+	_, _ = m.Update(keyPress("a"))
+
+	// Assert
+	if !m.confirm.Active {
+		t.Fatalf("pressing a should open the confirm dialog")
+	}
+	if m.pendingType != pihole.DomainAllow {
+		t.Fatalf("pending type should be allow, got %q", m.pendingType)
+	}
+	if m.confirm.Message != "ads.example.com" {
+		t.Fatalf("confirm should name the domain, got %q", m.confirm.Message)
+	}
+	if m.confirm.Danger {
+		t.Fatalf("allow confirm should not be styled as danger")
+	}
+}
+
+func TestPressingBlockOpensDangerConfirm(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+
+	// Act
+	_, _ = m.Update(keyPress("b"))
+
+	// Assert
+	if !m.confirm.Active {
+		t.Fatalf("pressing b should open the confirm dialog")
+	}
+	if m.pendingType != pihole.DomainDeny {
+		t.Fatalf("pending type should be deny, got %q", m.pendingType)
+	}
+	if !m.confirm.Danger {
+		t.Fatalf("block confirm should be styled as danger")
+	}
+}
+
+func TestAllowIgnoredWithNoSelection(t *testing.T) {
+	// Arrange: focused model with no rows
+	m := newTestModel()
+	m.SetSize(100, 24)
+	m.focused = true
+
+	// Act
+	_, _ = m.Update(keyPress("a"))
+
+	// Assert
+	if m.confirm.Active {
+		t.Fatalf("allow with no selected row should not open a confirm")
+	}
+}
+
+func TestQuickActionSuppressedWhileSearching(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+	m.searching = true
+	m.search.Focus()
+
+	// Act: 'a' should be typed into the search box, not open a confirm
+	_, _ = m.Update(keyPress("a"))
+
+	// Assert
+	if m.confirm.Active {
+		t.Fatalf("quick-classify must not trigger while the search field is focused")
+	}
+}
+
+func TestConfirmCancelHidesDialog(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+	_, _ = m.Update(keyPress("a"))
+
+	// Act
+	_, _ = m.Update(keyPress("n"))
+
+	// Assert
+	if m.confirm.Active {
+		t.Fatalf("n should dismiss the confirm dialog")
+	}
+	if m.pendingDomain != "" {
+		t.Fatalf("cancel should clear the pending domain, got %q", m.pendingDomain)
+	}
+}
+
+func TestConfirmAcceptClearsDialogAndDispatches(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+	_, _ = m.Update(keyPress("b"))
+
+	// Act
+	_, cmd := m.Update(keyPress("y"))
+
+	// Assert
+	if m.confirm.Active {
+		t.Fatalf("y should close the confirm dialog")
+	}
+	if cmd == nil {
+		t.Fatalf("y should dispatch the classify command")
+	}
+}
+
+func TestCapturesInputDuringConfirm(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+	_, _ = m.Update(keyPress("a"))
+
+	// Assert: while the confirm is up the screen must own y/n/esc so global
+	// shortcuts (d=toggle-block) and the esc-to-rail climb don't steal them.
+	if !m.CapturesInput() {
+		t.Fatalf("screen should capture input while the confirm dialog is active")
+	}
+}
+
+func TestClassifySuccessSetsNoteAndExpires(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+
+	// Act: a successful allow result
+	_, cmd := m.Update(classifyMsg{domain: "ads.example.com", verb: "allowed"})
+
+	// Assert
+	if m.note != "allowed ads.example.com" {
+		t.Fatalf("success should set the note, got %q", m.note)
+	}
+	if m.err != nil {
+		t.Fatalf("success should clear any error")
+	}
+	if cmd == nil {
+		t.Fatalf("success should schedule the note expiry")
+	}
+
+	// Act: the expiry fires
+	_, _ = m.Update(noteExpireMsg{})
+
+	// Assert
+	if m.note != "" {
+		t.Fatalf("note should clear on expiry, got %q", m.note)
+	}
+}
+
+func TestClassifyErrorSurfacesBanner(t *testing.T) {
+	// Arrange
+	m := modelWithQuery("ads.example.com")
+
+	// Act
+	_, _ = m.Update(classifyMsg{domain: "ads.example.com", verb: "blocked", err: errTest})
+
+	// Assert
+	if m.err == nil {
+		t.Fatalf("classify error should surface an error banner")
+	}
+	if m.note != "" {
+		t.Fatalf("classify error should not set a success note, got %q", m.note)
+	}
+}
+
+func TestClassifyWorksFromDetailPane(t *testing.T) {
+	// Arrange: detail pane open on a specific query
+	m := modelWithQuery("row.example.com")
+	d := pihole.Query{Domain: "detail.example.com"}
+	m.detail = &d
+
+	// Act
+	_, _ = m.Update(keyPress("a"))
+
+	// Assert: the confirm targets the detail domain, not the table cursor
+	if m.confirm.Message != "detail.example.com" {
+		t.Fatalf("classify from detail should target the detail domain, got %q", m.confirm.Message)
+	}
+}
+
+var errTest = testErr("boom")
+
+type testErr string
+
+func (e testErr) Error() string { return string(e) }


### PR DESCRIPTION
## Summary

Turns the Query Log from a viewer into a tool, and fixes the ragged sidebar spacing.

### Query Log quick-classify
- **`a`** allowlists / **`b`** blocklists the highlighted domain — works from both the table row and the open detail pane.
- Each action opens a **confirm dialog** (block variant styled danger-red); on confirm it calls `AddDomain` as an exact match with an `added from query log (tihole)` comment so entries are traceable in the Domains screen.
- Success shows a transient green **✓ toast** that self-clears after 4s; failures surface the existing error banner.
- Footer hint and Help updated to teach `a allow · b block`.

**Why `b` and not `d`:** `d` is the *global* toggle-blocking key and never reaches a screen. While the confirm is active the screen's `CapturesInput()` returns true so `y`/`n`/`esc` stay local instead of firing global shortcuts or climbing back to the rail. `classify()` runs on its own context so it never disturbs the live-poll cancel handle.

### Sidebar icon width fix
Four sidebar icons (Domains, Groups, Adlists, Settings) were emoji-presentation glyphs from the Misc Symbols block (U+2600–26FF) that most terminals render as **2 cells** while lipgloss/runewidth counts them as **1** — knocking every label out of alignment. Swapped for single-width BMP math/geometric symbols so all labels align.

## Test plan
- [x] New `quickclassify_test.go` (10 cases): confirm open/cancel/accept, danger styling, no-selection no-op, search suppression, input capture, note set+expiry, error banner, detail-pane targeting
- [x] Full suite: **831 passed**, build + vet clean
- [x] querylog package coverage **95.1%**