### PR TITLE
feat(tui): Gloss visual redesign — DeepNight theme, bleed-free surfaces, quick-classify

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+max_line_length = 80
+
+[*]
+indent_style = space
+indent_size = 2
+
+[{*[Mm]akefile*,*.mak,*.mk,depend,justfile}]
+indent_style = space
+indent_size = 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "editor.rulers": [80],
+  "[go]": {
+    "editor.rulers": [80],
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "golang.go"
+  },
+  "go.formatTool": "golines",
+  "go.formatFlags": [
+    "--max-len=80",
+    "--base-formatter=gofmt",
+    "--shorten-comments",
+    "--write-output"
+  ],
+  "golines": {
+    "maxLen": 80,
+    "shortenComments": true,
+    "reformatTags": true
+  }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,8 @@ func (i *Instance) VerifyTLSValue() bool {
 	return *i.VerifyTLS
 }
 
-// DefaultPath returns the default config path: <UserConfigDir>/tihole/config.yaml.
+// DefaultPath returns the default config path:
+// <UserConfigDir>/tihole/config.yaml.
 func DefaultPath() (string, error) {
 	dir, err := os.UserConfigDir()
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,12 @@ func validConfig() *Config {
 			"querylog":  2,
 		},
 		Instances: []Instance{
-			{Name: "home", URL: "https://192.168.1.2", Password: "secret", VerifyTLS: boolPtr(false)},
+			{
+				Name:      "home",
+				URL:       "https://192.168.1.2",
+				Password:  "secret",
+				VerifyTLS: boolPtr(false),
+			},
 		},
 	}
 }
@@ -59,7 +64,10 @@ func TestSaveThenLoadRoundTripsConfig(t *testing.T) {
 		t.Fatalf("instances not preserved: %+v", got.Instances)
 	}
 	if got.Instances[0].VerifyTLSValue() != false {
-		t.Fatalf("verify_tls not preserved, got %v", got.Instances[0].VerifyTLSValue())
+		t.Fatalf(
+			"verify_tls not preserved, got %v",
+			got.Instances[0].VerifyTLSValue(),
+		)
 	}
 	if got.Refresh["dashboard"] != 5 {
 		t.Fatalf("refresh not preserved: %+v", got.Refresh)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -73,7 +73,10 @@ func (i *Instance) ResolvePassword() (string, error) {
 		if v := os.Getenv(i.PasswordEnv); v != "" {
 			return v, nil
 		}
-		return "", fmt.Errorf("password_env %q is empty or unset", i.PasswordEnv)
+		return "", fmt.Errorf(
+			"password_env %q is empty or unset",
+			i.PasswordEnv,
+		)
 	}
 	return "", fmt.Errorf("instance %q has no password or password_env", i.Name)
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -67,7 +67,11 @@ func TestResolvePasswordErrorsWhenNeitherSet(t *testing.T) {
 func TestResolvePasswordPrefersInlineOverEnv(t *testing.T) {
 	// Arrange
 	t.Setenv("TIHOLE_TEST_PW2", "env-secret")
-	inst := Instance{Name: "home", Password: "inline", PasswordEnv: "TIHOLE_TEST_PW2"}
+	inst := Instance{
+		Name:        "home",
+		Password:    "inline",
+		PasswordEnv: "TIHOLE_TEST_PW2",
+	}
 
 	// Act
 	got, _ := inst.ResolvePassword()

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -29,7 +29,10 @@ func Validate(c *Config) error {
 	for idx, inst := range c.Instances {
 		name := strings.TrimSpace(inst.Name)
 		if name == "" {
-			errs = append(errs, fmt.Errorf("instance %d: name is required", idx))
+			errs = append(
+				errs,
+				fmt.Errorf("instance %d: name is required", idx),
+			)
 		} else if seen[name] {
 			errs = append(errs, fmt.Errorf("instance %q: duplicate name", name))
 		} else {
@@ -37,7 +40,10 @@ func Validate(c *Config) error {
 		}
 
 		if err := validateURL(inst.URL); err != nil {
-			errs = append(errs, fmt.Errorf("instance %q: %w", displayName(name, idx), err))
+			errs = append(
+				errs,
+				fmt.Errorf("instance %q: %w", displayName(name, idx), err),
+			)
 		}
 	}
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -49,7 +49,10 @@ func TestValidateRejectsActiveNotMatchingInstance(t *testing.T) {
 func TestValidateRejectsDuplicateNames(t *testing.T) {
 	// Arrange
 	c := validConfig()
-	c.Instances = append(c.Instances, Instance{Name: "home", URL: "https://10.0.0.2"})
+	c.Instances = append(
+		c.Instances,
+		Instance{Name: "home", URL: "https://10.0.0.2"},
+	)
 
 	// Act
 	err := Validate(c)

--- a/internal/config/wizard_test.go
+++ b/internal/config/wizard_test.go
@@ -27,7 +27,10 @@ instances:
 	// Assert
 	inst := c.Instances[0]
 	if inst.VerifyTLS != nil {
-		t.Fatalf("expected nil pointer for omitted verify_tls, got %v", *inst.VerifyTLS)
+		t.Fatalf(
+			"expected nil pointer for omitted verify_tls, got %v",
+			*inst.VerifyTLS,
+		)
 	}
 	if !inst.VerifyTLSValue() {
 		t.Fatal("omitted verify_tls should default to true")
@@ -59,7 +62,11 @@ instances:
 
 func TestBuildConfigProducesActiveSingleInstance(t *testing.T) {
 	// Arrange
-	in := wizardInputs{Name: " home ", URL: " https://192.168.1.2 ", Password: "secret"}
+	in := wizardInputs{
+		Name:     " home ",
+		URL:      " https://192.168.1.2 ",
+		Password: "secret",
+	}
 
 	// Act
 	c, err := buildConfig(in)
@@ -96,7 +103,11 @@ func TestFinishWritesConfigAndInvokesValidateFunc(t *testing.T) {
 		gotInst = inst
 		return nil
 	}}
-	in := wizardInputs{Name: "home", URL: "https://192.168.1.2", Password: "secret"}
+	in := wizardInputs{
+		Name:     "home",
+		URL:      "https://192.168.1.2",
+		Password: "secret",
+	}
 	path := filepath.Join(t.TempDir(), "config.yaml")
 
 	// Act
@@ -122,7 +133,11 @@ func TestFinishPropagatesValidateFuncError(t *testing.T) {
 	fr := &FirstRun{ValidateFunc: func(inst Instance) error {
 		return os.ErrPermission
 	}}
-	in := wizardInputs{Name: "home", URL: "https://192.168.1.2", Password: "secret"}
+	in := wizardInputs{
+		Name:     "home",
+		URL:      "https://192.168.1.2",
+		Password: "secret",
+	}
 	path := filepath.Join(t.TempDir(), "config.yaml")
 
 	// Act
@@ -153,7 +168,11 @@ func TestFinishRejectsInvalidInputs(t *testing.T) {
 
 func TestBuildConfigResultIsSavable(t *testing.T) {
 	// Arrange
-	in := wizardInputs{Name: "home", URL: "https://192.168.1.2", Password: "secret"}
+	in := wizardInputs{
+		Name:     "home",
+		URL:      "https://192.168.1.2",
+		Password: "secret",
+	}
 	c, err := buildConfig(in)
 	if err != nil {
 		t.Fatalf("buildConfig: %v", err)

--- a/internal/pihole/actions_test.go
+++ b/internal/pihole/actions_test.go
@@ -40,7 +40,11 @@ func TestFlushLogsPostsPath(t *testing.T) {
 		t.Fatalf("FlushLogs error: %v", err)
 	}
 	if gotMethod != http.MethodPost || gotPath != "/api/action/flush/logs" {
-		t.Errorf("got %s %s, want POST /api/action/flush/logs", gotMethod, gotPath)
+		t.Errorf(
+			"got %s %s, want POST /api/action/flush/logs",
+			gotMethod,
+			gotPath,
+		)
 	}
 }
 
@@ -57,15 +61,22 @@ func TestFlushNetworkPostsPath(t *testing.T) {
 		t.Fatalf("FlushNetwork error: %v", err)
 	}
 	if gotMethod != http.MethodPost || gotPath != "/api/action/flush/network" {
-		t.Errorf("got %s %s, want POST /api/action/flush/network", gotMethod, gotPath)
+		t.Errorf(
+			"got %s %s, want POST /api/action/flush/network",
+			gotMethod,
+			gotPath,
+		)
 	}
 }
 
 func TestDestructiveActionForbiddenSurfacesAPIError(t *testing.T) {
 	// Arrange: FTL returns 403 when allow_destructive is disabled.
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusForbidden,
-			`{"error":{"key":"forbidden","message":"destructive actions disabled","hint":"set allow_destructive"},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusForbidden,
+			`{"error":{"key":"forbidden","message":"destructive actions disabled","hint":"set allow_destructive"},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/auth_concurrency_test.go
+++ b/internal/pihole/auth_concurrency_test.go
@@ -27,8 +27,13 @@ func TestConcurrentRequestsLoginOnce(t *testing.T) {
 			authOK(w, sid)
 			return
 		}
-		if r.Header.Get("X-FTL-SID") == validSID.Load().(string) && validSID.Load().(string) != "" {
-			writeJSON(w, http.StatusOK, `{"blocking":"enabled","timer":null,"took":0.0}`)
+		if r.Header.Get("X-FTL-SID") == validSID.Load().(string) &&
+			validSID.Load().(string) != "" {
+			writeJSON(
+				w,
+				http.StatusOK,
+				`{"blocking":"enabled","timer":null,"took":0.0}`,
+			)
 			return
 		}
 		writeJSON(w, http.StatusUnauthorized,

--- a/internal/pihole/auth_test.go
+++ b/internal/pihole/auth_test.go
@@ -39,11 +39,13 @@ func TestLoginSuccess(t *testing.T) {
 func TestLoginWithTOTP(t *testing.T) {
 	// Arrange
 	var gotBody loginRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(data, &gotBody)
-		authOK(w, "SID-TOTP")
-	}))
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &gotBody)
+			authOK(w, "SID-TOTP")
+		}),
+	)
 	t.Cleanup(srv.Close)
 	client := New(srv.URL, "pw", WithHTTPClient(srv.Client()), WithTOTP(123456))
 
@@ -61,8 +63,11 @@ func TestLoginWithTOTP(t *testing.T) {
 func TestLoginInvalidCredentialsReturnsAuthError(t *testing.T) {
 	// Arrange
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusUnauthorized,
-			`{"error":{"key":"unauthorized","message":"Invalid password"},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusUnauthorized,
+			`{"error":{"key":"unauthorized","message":"Invalid password"},"took":0.0}`,
+		)
 	})
 
 	// Act
@@ -81,7 +86,11 @@ func TestLoginInvalidCredentialsReturnsAuthError(t *testing.T) {
 func TestLoginInvalidSessionBody(t *testing.T) {
 	// Arrange
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, `{"session":{"valid":false,"message":"nope"},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"session":{"valid":false,"message":"nope"},"took":0.0}`,
+		)
 	})
 
 	// Act

--- a/internal/pihole/blocking.go
+++ b/internal/pihole/blocking.go
@@ -22,8 +22,13 @@ type blockingRequest struct {
 }
 
 // SetBlocking sets the blocking state via POST /api/dns/blocking. timer is the
-// number of seconds after which blocking reverts, or nil for a permanent change.
-func (c *Client) SetBlocking(ctx context.Context, blocking bool, timer *float64) error {
+// number of seconds after which blocking reverts, or nil for a permanent
+// change.
+func (c *Client) SetBlocking(
+	ctx context.Context,
+	blocking bool,
+	timer *float64,
+) error {
 	reqBody := blockingRequest{Blocking: blocking, Timer: timer}
 	return c.do(ctx, http.MethodPost, "/dns/blocking", reqBody, nil)
 }

--- a/internal/pihole/blocking_test.go
+++ b/internal/pihole/blocking_test.go
@@ -16,7 +16,11 @@ func TestBlockingGet(t *testing.T) {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		// FTL v6 reports the state as a status STRING on GET, not a boolean.
-		writeJSON(w, http.StatusOK, `{"blocking":"disabled","timer":42,"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"blocking":"disabled","timer":42,"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -40,7 +44,11 @@ func TestBlockingGet(t *testing.T) {
 
 func TestBlockingGetNilTimer(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, `{"blocking":"enabled","timer":null,"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"blocking":"enabled","timer":null,"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -34,16 +34,22 @@ type Client struct {
 type Option func(*Client)
 
 // WithInsecureTLS enables or disables TLS certificate verification. Self-signed
-// certificates are common on PiHole installs, so pass true to skip verification.
+// certificates are common on PiHole installs, so pass true to skip
+// verification.
 func WithInsecureTLS(insecure bool) Option {
 	return func(c *Client) {
 		if !insecure {
 			return
 		}
 		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // opt-in per instance
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			}, //nolint:gosec // opt-in per instance
 		}
-		c.httpClient = &http.Client{Transport: transport, Timeout: c.httpClient.Timeout}
+		c.httpClient = &http.Client{
+			Transport: transport,
+			Timeout:   c.httpClient.Timeout,
+		}
 	}
 }
 
@@ -98,7 +104,11 @@ func (c *Client) setSID(sid string) {
 // relative to the /api root), marshaling body as JSON when non-nil and
 // decoding a 2xx response into out when non-nil. On a 401 it transparently logs
 // in once and retries. Non-2xx responses are decoded into an *APIError.
-func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+func (c *Client) do(
+	ctx context.Context,
+	method, path string,
+	body, out any,
+) error {
 	if err := c.doOnce(ctx, method, path, body, out, true, true); err != nil {
 		return err
 	}
@@ -124,7 +134,12 @@ func (c *Client) reauth(ctx context.Context, staleSID string) error {
 // 401, it re-authenticates (single-flight) and retries exactly once. sendAuth
 // controls whether the stored X-FTL-SID is attached — login itself passes false
 // so it never sends a stale session and never mutates shared state.
-func (c *Client) doOnce(ctx context.Context, method, path string, body, out any, allowRetry, sendAuth bool) error {
+func (c *Client) doOnce(
+	ctx context.Context,
+	method, path string,
+	body, out any,
+	allowRetry, sendAuth bool,
+) error {
 	var reqBody io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -143,7 +158,8 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body, out any,
 	}
 	req.Header.Set("Accept", "application/json")
 	// Header auth: send X-FTL-SID when we have a session. No CSRF token is
-	// required for header-based auth. Capture the SID we send so re-auth can tell
+	// required for header-based auth. Capture the SID we send so re-auth can
+	// tell
 	// whether another goroutine already refreshed it.
 	sentSID := ""
 	if sendAuth {
@@ -179,7 +195,12 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body, out any,
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return fmt.Errorf("pihole: decode %s %s response: %w", method, path, err)
+		return fmt.Errorf(
+			"pihole: decode %s %s response: %w",
+			method,
+			path,
+			err,
+		)
 	}
 	return nil
 }

--- a/internal/pihole/client_test.go
+++ b/internal/pihole/client_test.go
@@ -44,7 +44,13 @@ func TestDoSendsXFTLSIDHeader(t *testing.T) {
 	client.setSID("SID-AUTH")
 
 	// Act
-	err := client.do(context.Background(), http.MethodGet, "/stats/summary", nil, nil)
+	err := client.do(
+		context.Background(),
+		http.MethodGet,
+		"/stats/summary",
+		nil,
+		nil,
+	)
 
 	// Assert
 	if err != nil {
@@ -68,13 +74,19 @@ func TestDo401TriggersExactlyOneReauthAndRetry(t *testing.T) {
 			n := atomic.AddInt32(&protectedCalls, 1)
 			if n == 1 {
 				// First hit: pretend the (empty) session is invalid.
-				writeJSON(w, http.StatusUnauthorized,
-					`{"error":{"key":"unauthorized","message":"no session"},"took":0.0}`)
+				writeJSON(
+					w,
+					http.StatusUnauthorized,
+					`{"error":{"key":"unauthorized","message":"no session"},"took":0.0}`,
+				)
 				return
 			}
 			// Retry must carry the freshly-minted SID.
 			if r.Header.Get("X-FTL-SID") != "FRESH-SID" {
-				t.Errorf("retry X-FTL-SID = %q, want FRESH-SID", r.Header.Get("X-FTL-SID"))
+				t.Errorf(
+					"retry X-FTL-SID = %q, want FRESH-SID",
+					r.Header.Get("X-FTL-SID"),
+				)
 			}
 			writeJSON(w, http.StatusOK, `{"took":0.0}`)
 		default:
@@ -83,7 +95,13 @@ func TestDo401TriggersExactlyOneReauthAndRetry(t *testing.T) {
 	})
 
 	// Act
-	err := client.do(context.Background(), http.MethodGet, "/stats/summary", nil, nil)
+	err := client.do(
+		context.Background(),
+		http.MethodGet,
+		"/stats/summary",
+		nil,
+		nil,
+	)
 
 	// Assert
 	if err != nil {
@@ -93,7 +111,10 @@ func TestDo401TriggersExactlyOneReauthAndRetry(t *testing.T) {
 		t.Errorf("auth called %d times, want exactly 1", got)
 	}
 	if got := atomic.LoadInt32(&protectedCalls); got != 2 {
-		t.Errorf("protected endpoint called %d times, want 2 (original + retry)", got)
+		t.Errorf(
+			"protected endpoint called %d times, want 2 (original + retry)",
+			got,
+		)
 	}
 }
 
@@ -109,9 +130,16 @@ func TestDo401RetryStillFailsReturnsAPIError(t *testing.T) {
 	})
 
 	// Act
-	err := client.do(context.Background(), http.MethodGet, "/stats/summary", nil, nil)
+	err := client.do(
+		context.Background(),
+		http.MethodGet,
+		"/stats/summary",
+		nil,
+		nil,
+	)
 
-	// Assert: retry disabled on the second pass, so the 401 surfaces as APIError.
+	// Assert: retry disabled on the second pass, so the 401 surfaces as
+	// APIError.
 	apiErr, ok := err.(*APIError)
 	if !ok {
 		t.Fatalf("error type = %T, want *APIError", err)
@@ -124,13 +152,22 @@ func TestDo401RetryStillFailsReturnsAPIError(t *testing.T) {
 func TestDoDecodesErrorEnvelope(t *testing.T) {
 	// Arrange
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusForbidden,
-			`{"error":{"key":"forbidden","message":"Destructive action","hint":"set allow_destructive"},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusForbidden,
+			`{"error":{"key":"forbidden","message":"Destructive action","hint":"set allow_destructive"},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
 	// Act
-	err := client.do(context.Background(), http.MethodPost, "/action/restartdns", nil, nil)
+	err := client.do(
+		context.Background(),
+		http.MethodPost,
+		"/action/restartdns",
+		nil,
+		nil,
+	)
 
 	// Assert
 	apiErr, ok := err.(*APIError)
@@ -145,13 +182,21 @@ func TestDoDecodesErrorEnvelope(t *testing.T) {
 
 func TestDoNetworkErrorOnUnreachableHost(t *testing.T) {
 	// Arrange: point at a closed port.
-	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+	)
 	url := srv.URL
 	srv.Close() // now unreachable
 	client := New(url, "pw")
 
 	// Act
-	err := client.do(context.Background(), http.MethodGet, "/stats/summary", nil, nil)
+	err := client.do(
+		context.Background(),
+		http.MethodGet,
+		"/stats/summary",
+		nil,
+		nil,
+	)
 
 	// Assert
 	if _, ok := err.(*NetworkError); !ok {
@@ -161,13 +206,15 @@ func TestDoNetworkErrorOnUnreachableHost(t *testing.T) {
 
 func TestWithInsecureTLSWiresSkipVerify(t *testing.T) {
 	// Arrange: a TLS server with a self-signed cert.
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/auth" {
-			authOK(w, "SID")
-			return
-		}
-		writeJSON(w, http.StatusOK, `{"took":0.0}`)
-	}))
+	srv := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/auth" {
+				authOK(w, "SID")
+				return
+			}
+			writeJSON(w, http.StatusOK, `{"took":0.0}`)
+		}),
+	)
 	t.Cleanup(srv.Close)
 
 	// A default client (no insecure opt-in) must fail the TLS handshake.
@@ -182,7 +229,10 @@ func TestWithInsecureTLSWiresSkipVerify(t *testing.T) {
 	// Assert: the transport carries InsecureSkipVerify and the call succeeds.
 	tr, ok := insecure.httpClient.Transport.(*http.Transport)
 	if !ok {
-		t.Fatalf("transport type = %T, want *http.Transport", insecure.httpClient.Transport)
+		t.Fatalf(
+			"transport type = %T, want *http.Transport",
+			insecure.httpClient.Transport,
+		)
 	}
 	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
 		t.Errorf("InsecureSkipVerify not set on transport")

--- a/internal/pihole/clients.go
+++ b/internal/pihole/clients.go
@@ -68,8 +68,16 @@ func (c *Client) Clients(ctx context.Context) ([]ClientEntry, error) {
 }
 
 // AddClient creates a client via POST /api/clients.
-func (c *Client) AddClient(ctx context.Context, client, comment string, groups []int) (ClientEntry, error) {
-	body := clientCreateRequest{Client: client, Comment: comment, Groups: groups}
+func (c *Client) AddClient(
+	ctx context.Context,
+	client, comment string,
+	groups []int,
+) (ClientEntry, error) {
+	body := clientCreateRequest{
+		Client:  client,
+		Comment: comment,
+		Groups:  groups,
+	}
 	var out clientsEnvelope
 	if err := c.do(ctx, http.MethodPost, "/clients", body, &out); err != nil {
 		return ClientEntry{}, err
@@ -81,7 +89,11 @@ func (c *Client) AddClient(ctx context.Context, client, comment string, groups [
 }
 
 // UpdateClient updates a client via PUT /api/clients/{client}.
-func (c *Client) UpdateClient(ctx context.Context, client, comment string, groups []int) (ClientEntry, error) {
+func (c *Client) UpdateClient(
+	ctx context.Context,
+	client, comment string,
+	groups []int,
+) (ClientEntry, error) {
 	body := clientUpdateRequest{Comment: comment, Groups: groups}
 	path := "/clients/" + url.PathEscape(client)
 	var out clientsEnvelope
@@ -96,12 +108,20 @@ func (c *Client) UpdateClient(ctx context.Context, client, comment string, group
 
 // DeleteClient removes a client via DELETE /api/clients/{client}.
 func (c *Client) DeleteClient(ctx context.Context, client string) error {
-	return c.do(ctx, http.MethodDelete, "/clients/"+url.PathEscape(client), nil, nil)
+	return c.do(
+		ctx,
+		http.MethodDelete,
+		"/clients/"+url.PathEscape(client),
+		nil,
+		nil,
+	)
 }
 
 // ClientSuggestions fetches GET /api/clients/_suggestions — clients seen in
 // queries that are not yet configured.
-func (c *Client) ClientSuggestions(ctx context.Context) ([]ClientSuggestion, error) {
+func (c *Client) ClientSuggestions(
+	ctx context.Context,
+) ([]ClientSuggestion, error) {
 	var out suggestionsEnvelope
 	if err := c.do(ctx, http.MethodGet, "/clients/_suggestions", nil, &out); err != nil {
 		return nil, err
@@ -109,7 +129,11 @@ func (c *Client) ClientSuggestions(ctx context.Context) ([]ClientSuggestion, err
 	return out.Clients, nil
 }
 
-// BatchDeleteClients removes multiple clients via POST /api/clients:batchDelete.
-func (c *Client) BatchDeleteClients(ctx context.Context, items []ClientRef) error {
+// BatchDeleteClients removes multiple clients via POST
+// /api/clients:batchDelete.
+func (c *Client) BatchDeleteClients(
+	ctx context.Context,
+	items []ClientRef,
+) error {
 	return c.do(ctx, http.MethodPost, "/clients:batchDelete", items, nil)
 }

--- a/internal/pihole/clients_test.go
+++ b/internal/pihole/clients_test.go
@@ -13,7 +13,11 @@ func TestClientsListDecodes(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != "/api/clients" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"clients":[{"client":"192.168.1.5","comment":"laptop","groups":[0,2],"id":3}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"clients":[{"client":"192.168.1.5","comment":"laptop","groups":[0,2],"id":3}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -21,7 +25,8 @@ func TestClientsListDecodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Clients error: %v", err)
 	}
-	if len(got) != 1 || got[0].Client != "192.168.1.5" || len(got[0].Groups) != 2 {
+	if len(got) != 1 || got[0].Client != "192.168.1.5" ||
+		len(got[0].Groups) != 2 {
 		t.Errorf("got = %+v, want client 192.168.1.5 with 2 groups", got)
 	}
 }
@@ -34,32 +39,52 @@ func TestAddClientPostsBody(t *testing.T) {
 		}
 		data, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(data, &gotBody)
-		writeJSON(w, http.StatusCreated, `{"clients":[{"client":"192.168.1.5","id":8}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusCreated,
+			`{"clients":[{"client":"192.168.1.5","id":8}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
-	got, err := client.AddClient(context.Background(), "192.168.1.5", "laptop", []int{2})
+	got, err := client.AddClient(
+		context.Background(),
+		"192.168.1.5",
+		"laptop",
+		[]int{2},
+	)
 	if err != nil {
 		t.Fatalf("AddClient error: %v", err)
 	}
 	if got.ID != 8 {
 		t.Errorf("got id = %d, want 8", got.ID)
 	}
-	if gotBody.Client != "192.168.1.5" || gotBody.Comment != "laptop" || len(gotBody.Groups) != 1 {
+	if gotBody.Client != "192.168.1.5" || gotBody.Comment != "laptop" ||
+		len(gotBody.Groups) != 1 {
 		t.Errorf("body = %+v, want client/comment/groups set", gotBody)
 	}
 }
 
 func TestUpdateClientPutsToClientPath(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/api/clients/192.168.1.5" {
+		if r.Method != http.MethodPut ||
+			r.URL.Path != "/api/clients/192.168.1.5" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"clients":[{"client":"192.168.1.5","id":8}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"clients":[{"client":"192.168.1.5","id":8}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
-	got, err := client.UpdateClient(context.Background(), "192.168.1.5", "renamed", []int{1})
+	got, err := client.UpdateClient(
+		context.Background(),
+		"192.168.1.5",
+		"renamed",
+		[]int{1},
+	)
 	if err != nil {
 		t.Fatalf("UpdateClient error: %v", err)
 	}
@@ -70,7 +95,8 @@ func TestUpdateClientPutsToClientPath(t *testing.T) {
 
 func TestDeleteClientReturns204(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/api/clients/192.168.1.5" {
+		if r.Method != http.MethodDelete ||
+			r.URL.Path != "/api/clients/192.168.1.5" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -84,10 +110,15 @@ func TestDeleteClientReturns204(t *testing.T) {
 
 func TestClientSuggestionsDecodes(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || r.URL.Path != "/api/clients/_suggestions" {
+		if r.Method != http.MethodGet ||
+			r.URL.Path != "/api/clients/_suggestions" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"clients":[{"hwaddr":"aa:bb","macVendor":"Acme","lastQuery":123,"name":"tv","addresses":"10.0.0.9"}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"clients":[{"hwaddr":"aa:bb","macVendor":"Acme","lastQuery":123,"name":"tv","addresses":"10.0.0.9"}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -112,7 +143,10 @@ func TestBatchDeleteClientsSendsItemBody(t *testing.T) {
 	})
 	client.setSID("S")
 
-	err := client.BatchDeleteClients(context.Background(), []ClientRef{{Item: "192.168.1.5"}})
+	err := client.BatchDeleteClients(
+		context.Background(),
+		[]ClientRef{{Item: "192.168.1.5"}},
+	)
 	if err != nil {
 		t.Fatalf("BatchDeleteClients error: %v", err)
 	}

--- a/internal/pihole/config.go
+++ b/internal/pihole/config.go
@@ -28,7 +28,10 @@ func escapeElement(element string) string {
 // Config fetches GET /api/config — the full configuration tree. When detailed
 // is true, FTL annotates each leaf with metadata; otherwise raw values are
 // returned. The decoded `config` object is returned as an open-ended tree.
-func (c *Client) Config(ctx context.Context, detailed bool) (map[string]any, error) {
+func (c *Client) Config(
+	ctx context.Context,
+	detailed bool,
+) (map[string]any, error) {
 	path := fmt.Sprintf("/config?detailed=%t", detailed)
 	var out configEnvelope
 	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
@@ -39,7 +42,10 @@ func (c *Client) Config(ctx context.Context, detailed bool) (map[string]any, err
 
 // ConfigElement fetches GET /api/config/{element} — a single subtree addressed
 // by a dotted path such as "dns.upstreams". Each path segment is escaped.
-func (c *Client) ConfigElement(ctx context.Context, element string) (map[string]any, error) {
+func (c *Client) ConfigElement(
+	ctx context.Context,
+	element string,
+) (map[string]any, error) {
 	path := "/config/" + escapeElement(element)
 	var out configEnvelope
 	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
@@ -56,7 +62,11 @@ type configPatchRequest struct {
 // PatchConfig applies a partial config update via PATCH /api/config. The patch
 // is sent under the `config` key. When restart is true FTL restarts affected
 // subsystems to apply the change immediately.
-func (c *Client) PatchConfig(ctx context.Context, patch map[string]any, restart bool) error {
+func (c *Client) PatchConfig(
+	ctx context.Context,
+	patch map[string]any,
+	restart bool,
+) error {
 	path := fmt.Sprintf("/config?restart=%t", restart)
 	body := configPatchRequest{Config: patch}
 	return c.do(ctx, http.MethodPatch, path, body, nil)
@@ -65,14 +75,20 @@ func (c *Client) PatchConfig(ctx context.Context, patch map[string]any, restart 
 // AddConfigItem appends value to an array-valued config element via
 // PUT /api/config/{element}/{value}. Both the element path and the value are
 // escaped as path segments.
-func (c *Client) AddConfigItem(ctx context.Context, element, value string) error {
+func (c *Client) AddConfigItem(
+	ctx context.Context,
+	element, value string,
+) error {
 	path := "/config/" + escapeElement(element) + "/" + url.PathEscape(value)
 	return c.do(ctx, http.MethodPut, path, nil, nil)
 }
 
 // DeleteConfigItem removes value from an array-valued config element via
 // DELETE /api/config/{element}/{value}.
-func (c *Client) DeleteConfigItem(ctx context.Context, element, value string) error {
+func (c *Client) DeleteConfigItem(
+	ctx context.Context,
+	element, value string,
+) error {
 	path := "/config/" + escapeElement(element) + "/" + url.PathEscape(value)
 	return c.do(ctx, http.MethodDelete, path, nil, nil)
 }

--- a/internal/pihole/config_test.go
+++ b/internal/pihole/config_test.go
@@ -17,7 +17,11 @@ func TestConfigDecodesTree(t *testing.T) {
 		if got := r.URL.Query().Get("detailed"); got != "true" {
 			t.Errorf("detailed = %q, want true", got)
 		}
-		writeJSON(w, http.StatusOK, `{"config":{"dns":{"port":53},"dhcp":{"active":false}},"took":0.1}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"config":{"dns":{"port":53},"dhcp":{"active":false}},"took":0.1}`,
+		)
 	})
 	client.setSID("S")
 
@@ -57,7 +61,11 @@ func TestConfigElementEscapesDottedPath(t *testing.T) {
 		if r.URL.Path != "/api/config/dns/upstreams" {
 			t.Errorf("path = %q, want /api/config/dns/upstreams", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"config":{"dns":{"upstreams":["1.1.1.1"]}},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"config":{"dns":{"upstreams":["1.1.1.1"]}},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -90,7 +98,11 @@ func TestPatchConfigBodyAndRestartParam(t *testing.T) {
 	client.setSID("S")
 
 	// Act
-	err := client.PatchConfig(context.Background(), map[string]any{"dns": map[string]any{"port": 5353}}, true)
+	err := client.PatchConfig(
+		context.Background(),
+		map[string]any{"dns": map[string]any{"port": 5353}},
+		true,
+	)
 
 	// Assert
 	if err != nil {
@@ -113,7 +125,11 @@ func TestAddConfigItemPath(t *testing.T) {
 	client.setSID("S")
 
 	// Act
-	err := client.AddConfigItem(context.Background(), "dns.upstreams", "1.1.1.1")
+	err := client.AddConfigItem(
+		context.Background(),
+		"dns.upstreams",
+		"1.1.1.1",
+	)
 
 	// Assert
 	if err != nil {

--- a/internal/pihole/dns_records.go
+++ b/internal/pihole/dns_records.go
@@ -92,7 +92,10 @@ func (c *Client) AddHostRecord(ctx context.Context, ip, domain string) error {
 
 // DeleteHostRecord removes an A/AAAA host entry via
 // DELETE /api/config/dns/hosts/{IP domain}.
-func (c *Client) DeleteHostRecord(ctx context.Context, ip, domain string) error {
+func (c *Client) DeleteHostRecord(
+	ctx context.Context,
+	ip, domain string,
+) error {
 	return c.DeleteConfigItem(ctx, "dns.hosts", hostValue(ip, domain))
 }
 
@@ -112,20 +115,39 @@ func (c *Client) CNAMERecords(ctx context.Context) ([]CNAMERecord, error) {
 
 // AddCNAMERecord appends a CNAME entry via
 // PUT /api/config/dns/cnameRecords/{value}. A non-positive ttl is omitted.
-func (c *Client) AddCNAMERecord(ctx context.Context, domain, target string, ttl int) error {
-	return c.AddConfigItem(ctx, "dns.cnameRecords", cnameValue(domain, target, ttl))
+func (c *Client) AddCNAMERecord(
+	ctx context.Context,
+	domain, target string,
+	ttl int,
+) error {
+	return c.AddConfigItem(
+		ctx,
+		"dns.cnameRecords",
+		cnameValue(domain, target, ttl),
+	)
 }
 
 // DeleteCNAMERecord removes a CNAME entry via
 // DELETE /api/config/dns/cnameRecords/{value}.
-func (c *Client) DeleteCNAMERecord(ctx context.Context, domain, target string, ttl int) error {
-	return c.DeleteConfigItem(ctx, "dns.cnameRecords", cnameValue(domain, target, ttl))
+func (c *Client) DeleteCNAMERecord(
+	ctx context.Context,
+	domain, target string,
+	ttl int,
+) error {
+	return c.DeleteConfigItem(
+		ctx,
+		"dns.cnameRecords",
+		cnameValue(domain, target, ttl),
+	)
 }
 
 // stringArrayElement fetches a config element whose value is a JSON array of
 // strings, following the same dotted-element addressing as ConfigElement. The
 // element's value lives at config[<last segment>] in the response subtree.
-func (c *Client) stringArrayElement(ctx context.Context, element string) ([]string, error) {
+func (c *Client) stringArrayElement(
+	ctx context.Context,
+	element string,
+) ([]string, error) {
 	path := "/config/" + escapeElement(element)
 	var out stringArrayEnvelope
 	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {

--- a/internal/pihole/dns_records_test.go
+++ b/internal/pihole/dns_records_test.go
@@ -12,8 +12,11 @@ func TestHostRecordsParse(t *testing.T) {
 		if r.URL.Path != "/api/config/dns/hosts" {
 			t.Errorf("path = %q, want /api/config/dns/hosts", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"config":{"dns":{"hosts":["192.168.1.10 nas.local","10.0.0.5 printer.local"]}},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"config":{"dns":{"hosts":["192.168.1.10 nas.local","10.0.0.5 printer.local"]}},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -46,7 +49,11 @@ func TestAddHostRecordEscapesValueAsOneSegment(t *testing.T) {
 	client.setSID("S")
 
 	// Act
-	err := client.AddHostRecord(context.Background(), "192.168.1.10", "nas.local")
+	err := client.AddHostRecord(
+		context.Background(),
+		"192.168.1.10",
+		"nas.local",
+	)
 
 	// Assert
 	if err != nil {
@@ -87,8 +94,11 @@ func TestCNAMERecordsParse(t *testing.T) {
 		if r.URL.Path != "/api/config/dns/cnameRecords" {
 			t.Errorf("path = %q, want /api/config/dns/cnameRecords", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"config":{"dns":{"cnameRecords":["www.example.com,example.com,3600","alias.local,host.local"]}},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"config":{"dns":{"cnameRecords":["www.example.com,example.com,3600","alias.local,host.local"]}},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/domains.go
+++ b/internal/pihole/domains.go
@@ -76,7 +76,13 @@ func (c *Client) Domains(ctx context.Context) ([]Domain, error) {
 
 // AddDomain creates a domain via POST /api/domains/{type}/{kind}/{domain}. The
 // new entry is created enabled.
-func (c *Client) AddDomain(ctx context.Context, dt DomainType, dk DomainKind, domain, comment string, groups []int) (Domain, error) {
+func (c *Client) AddDomain(
+	ctx context.Context,
+	dt DomainType,
+	dk DomainKind,
+	domain, comment string,
+	groups []int,
+) (Domain, error) {
 	body := domainRequest{Comment: comment, Groups: groups, Enabled: true}
 	var out domainsEnvelope
 	if err := c.do(ctx, http.MethodPost, domainPath(dt, dk, domain), body, &out); err != nil {
@@ -89,7 +95,14 @@ func (c *Client) AddDomain(ctx context.Context, dt DomainType, dk DomainKind, do
 }
 
 // UpdateDomain updates a domain via PUT /api/domains/{type}/{kind}/{domain}.
-func (c *Client) UpdateDomain(ctx context.Context, dt DomainType, dk DomainKind, domain, comment string, groups []int, enabled bool) (Domain, error) {
+func (c *Client) UpdateDomain(
+	ctx context.Context,
+	dt DomainType,
+	dk DomainKind,
+	domain, comment string,
+	groups []int,
+	enabled bool,
+) (Domain, error) {
 	body := domainRequest{Comment: comment, Groups: groups, Enabled: enabled}
 	var out domainsEnvelope
 	if err := c.do(ctx, http.MethodPut, domainPath(dt, dk, domain), body, &out); err != nil {
@@ -102,11 +115,20 @@ func (c *Client) UpdateDomain(ctx context.Context, dt DomainType, dk DomainKind,
 }
 
 // DeleteDomain removes a domain via DELETE /api/domains/{type}/{kind}/{domain}.
-func (c *Client) DeleteDomain(ctx context.Context, dt DomainType, dk DomainKind, domain string) error {
+func (c *Client) DeleteDomain(
+	ctx context.Context,
+	dt DomainType,
+	dk DomainKind,
+	domain string,
+) error {
 	return c.do(ctx, http.MethodDelete, domainPath(dt, dk, domain), nil, nil)
 }
 
-// BatchDeleteDomains removes multiple domains via POST /api/domains:batchDelete.
-func (c *Client) BatchDeleteDomains(ctx context.Context, items []DomainRef) error {
+// BatchDeleteDomains removes multiple domains via POST
+// /api/domains:batchDelete.
+func (c *Client) BatchDeleteDomains(
+	ctx context.Context,
+	items []DomainRef,
+) error {
 	return c.do(ctx, http.MethodPost, "/domains:batchDelete", items, nil)
 }

--- a/internal/pihole/domains_test.go
+++ b/internal/pihole/domains_test.go
@@ -14,7 +14,11 @@ func TestDomainsListDecodes(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != "/api/domains" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"domains":[{"domain":"ads.example.com","type":"deny","kind":"exact","comment":"junk","groups":[0],"enabled":true,"id":7,"date_added":100,"date_modified":200}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"domains":[{"domain":"ads.example.com","type":"deny","kind":"exact","comment":"junk","groups":[0],"enabled":true,"id":7,"date_added":100,"date_modified":200}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -25,7 +29,8 @@ func TestDomainsListDecodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Domains error: %v", err)
 	}
-	if len(got) != 1 || got[0].Domain != "ads.example.com" || got[0].ID != 7 || !got[0].Enabled {
+	if len(got) != 1 || got[0].Domain != "ads.example.com" || got[0].ID != 7 ||
+		!got[0].Enabled {
 		t.Errorf("got = %+v, want one enabled domain id=7", got)
 	}
 }
@@ -34,17 +39,29 @@ func TestAddDomainPostsBodyAndEchoes(t *testing.T) {
 	// Arrange
 	var gotBody domainRequest
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/api/domains/deny/exact/ads.example.com" {
+		if r.Method != http.MethodPost ||
+			r.URL.Path != "/api/domains/deny/exact/ads.example.com" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		data, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(data, &gotBody)
-		writeJSON(w, http.StatusCreated, `{"domains":[{"domain":"ads.example.com","type":"deny","kind":"exact","comment":"junk","groups":[1],"enabled":true,"id":9}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusCreated,
+			`{"domains":[{"domain":"ads.example.com","type":"deny","kind":"exact","comment":"junk","groups":[1],"enabled":true,"id":9}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
 	// Act
-	got, err := client.AddDomain(context.Background(), DomainDeny, KindExact, "ads.example.com", "junk", []int{1})
+	got, err := client.AddDomain(
+		context.Background(),
+		DomainDeny,
+		KindExact,
+		"ads.example.com",
+		"junk",
+		[]int{1},
+	)
 
 	// Assert
 	if err != nil {
@@ -53,7 +70,9 @@ func TestAddDomainPostsBodyAndEchoes(t *testing.T) {
 	if got.ID != 9 || got.Domain != "ads.example.com" {
 		t.Errorf("got = %+v, want id=9", got)
 	}
-	if gotBody.Comment != "junk" || !gotBody.Enabled || len(gotBody.Groups) != 1 || gotBody.Groups[0] != 1 {
+	if gotBody.Comment != "junk" || !gotBody.Enabled ||
+		len(gotBody.Groups) != 1 ||
+		gotBody.Groups[0] != 1 {
 		t.Errorf("body = %+v, want comment=junk enabled groups=[1]", gotBody)
 	}
 }
@@ -63,12 +82,23 @@ func TestAddDomainRegexEscapesPath(t *testing.T) {
 	var gotRawPath string
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
 		gotRawPath = r.RequestURI
-		writeJSON(w, http.StatusCreated, `{"domains":[{"domain":"(^|\\.)ads\\.com$","type":"allow","kind":"regex","id":3}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusCreated,
+			`{"domains":[{"domain":"(^|\\.)ads\\.com$","type":"allow","kind":"regex","id":3}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
 	// Act
-	_, err := client.AddDomain(context.Background(), DomainAllow, KindRegex, `(^|\.)ads\.com$`, "", nil)
+	_, err := client.AddDomain(
+		context.Background(),
+		DomainAllow,
+		KindRegex,
+		`(^|\.)ads\.com$`,
+		"",
+		nil,
+	)
 
 	// Assert
 	if err != nil {
@@ -84,17 +114,30 @@ func TestUpdateDomainPutsBody(t *testing.T) {
 	// Arrange
 	var gotBody domainRequest
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/api/domains/allow/exact/ok.example.com" {
+		if r.Method != http.MethodPut ||
+			r.URL.Path != "/api/domains/allow/exact/ok.example.com" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		data, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(data, &gotBody)
-		writeJSON(w, http.StatusOK, `{"domains":[{"domain":"ok.example.com","enabled":false,"id":4}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"domains":[{"domain":"ok.example.com","enabled":false,"id":4}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
 	// Act
-	got, err := client.UpdateDomain(context.Background(), DomainAllow, KindExact, "ok.example.com", "note", []int{2}, false)
+	got, err := client.UpdateDomain(
+		context.Background(),
+		DomainAllow,
+		KindExact,
+		"ok.example.com",
+		"note",
+		[]int{2},
+		false,
+	)
 
 	// Assert
 	if err != nil {
@@ -111,7 +154,8 @@ func TestUpdateDomainPutsBody(t *testing.T) {
 func TestDeleteDomainReturns204(t *testing.T) {
 	// Arrange
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/api/domains/deny/exact/x.example.com" {
+		if r.Method != http.MethodDelete ||
+			r.URL.Path != "/api/domains/deny/exact/x.example.com" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -119,7 +163,12 @@ func TestDeleteDomainReturns204(t *testing.T) {
 	client.setSID("S")
 
 	// Act
-	err := client.DeleteDomain(context.Background(), DomainDeny, KindExact, "x.example.com")
+	err := client.DeleteDomain(
+		context.Background(),
+		DomainDeny,
+		KindExact,
+		"x.example.com",
+	)
 
 	// Assert
 	if err != nil {
@@ -131,7 +180,8 @@ func TestBatchDeleteDomainsSendsItemBody(t *testing.T) {
 	// Arrange
 	var raw []map[string]any
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/api/domains:batchDelete" {
+		if r.Method != http.MethodPost ||
+			r.URL.Path != "/api/domains:batchDelete" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		data, _ := io.ReadAll(r.Body)

--- a/internal/pihole/errors.go
+++ b/internal/pihole/errors.go
@@ -40,7 +40,12 @@ func (e *APIError) Error() string {
 		return fmt.Sprintf("pihole: %s (status %d, key %q): %s [hint: %s]",
 			e.Message, e.Status, e.Key, e.Message, e.Hint)
 	}
-	return fmt.Sprintf("pihole: %s (status %d, key %q)", e.Message, e.Status, e.Key)
+	return fmt.Sprintf(
+		"pihole: %s (status %d, key %q)",
+		e.Message,
+		e.Status,
+		e.Key,
+	)
 }
 
 // AuthError indicates an authentication or authorization failure that could
@@ -51,7 +56,11 @@ type AuthError struct {
 }
 
 func (e *AuthError) Error() string {
-	return fmt.Sprintf("pihole: authentication failed (status %d): %s", e.Status, e.Message)
+	return fmt.Sprintf(
+		"pihole: authentication failed (status %d): %s",
+		e.Status,
+		e.Message,
+	)
 }
 
 // NetworkError wraps a transport-level failure (DNS, connection refused, TLS,

--- a/internal/pihole/errors_test.go
+++ b/internal/pihole/errors_test.go
@@ -76,8 +76,10 @@ func TestDecodeAPIError(t *testing.T) {
 			if got.Hint != tt.wantHint {
 				t.Errorf("Hint = %q, want %q", got.Hint, tt.wantHint)
 			}
-			// A decoded error must never carry a raw JSON body through to the UI.
-			if strings.HasPrefix(strings.TrimSpace(tt.body), "{") && strings.Contains(got.Message, "{") {
+			// A decoded error must never carry a raw JSON body through to the
+			// UI.
+			if strings.HasPrefix(strings.TrimSpace(tt.body), "{") &&
+				strings.Contains(got.Message, "{") {
 				t.Errorf("Message leaks raw JSON body: %q", got.Message)
 			}
 		})
@@ -86,7 +88,12 @@ func TestDecodeAPIError(t *testing.T) {
 
 func TestAPIErrorMessageIncludesHint(t *testing.T) {
 	// Arrange
-	e := &APIError{Status: 403, Key: "forbidden", Message: "denied", Hint: "set allow_destructive"}
+	e := &APIError{
+		Status:  403,
+		Key:     "forbidden",
+		Message: "denied",
+		Hint:    "set allow_destructive",
+	}
 
 	// Act
 	msg := e.Error()

--- a/internal/pihole/gravity.go
+++ b/internal/pihole/gravity.go
@@ -16,8 +16,17 @@ func (c *Client) UpdateGravity(ctx context.Context, onLine func(string)) error {
 	return c.streamGravity(ctx, onLine, true)
 }
 
-func (c *Client) streamGravity(ctx context.Context, onLine func(string), allowRetry bool) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL+"/action/gravity", nil)
+func (c *Client) streamGravity(
+	ctx context.Context,
+	onLine func(string),
+	allowRetry bool,
+) error {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.apiURL+"/action/gravity",
+		nil,
+	)
 	if err != nil {
 		return &NetworkError{Op: "POST /action/gravity", Err: err}
 	}

--- a/internal/pihole/gravity_test.go
+++ b/internal/pihole/gravity_test.go
@@ -8,7 +8,11 @@ import (
 
 func TestUpdateGravityStreamsLines(t *testing.T) {
 	// Arrange
-	lines := []string{"  [i] Building tree", "  [i] Updating gravity", "  [✓] Done"}
+	lines := []string{
+		"  [i] Building tree",
+		"  [i] Updating gravity",
+		"  [✓] Done",
+	}
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/api/action/gravity" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
@@ -48,7 +52,11 @@ func TestUpdateGravityStreamsLines(t *testing.T) {
 
 func TestUpdateGravityPropagatesAPIError(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusForbidden, `{"error":{"key":"forbidden","message":"nope"},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusForbidden,
+			`{"error":{"key":"forbidden","message":"nope"},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/groups.go
+++ b/internal/pihole/groups.go
@@ -50,7 +50,10 @@ func (c *Client) Groups(ctx context.Context) ([]Group, error) {
 }
 
 // AddGroup creates a group via POST /api/groups. The new group is enabled.
-func (c *Client) AddGroup(ctx context.Context, name, comment string) (Group, error) {
+func (c *Client) AddGroup(
+	ctx context.Context,
+	name, comment string,
+) (Group, error) {
 	body := groupCreateRequest{Name: name, Comment: comment, Enabled: true}
 	var out groupsEnvelope
 	if err := c.do(ctx, http.MethodPost, "/groups", body, &out); err != nil {
@@ -63,7 +66,11 @@ func (c *Client) AddGroup(ctx context.Context, name, comment string) (Group, err
 }
 
 // UpdateGroup updates a group via PUT /api/groups/{name}.
-func (c *Client) UpdateGroup(ctx context.Context, name, comment string, enabled bool) (Group, error) {
+func (c *Client) UpdateGroup(
+	ctx context.Context,
+	name, comment string,
+	enabled bool,
+) (Group, error) {
 	body := groupUpdateRequest{Comment: comment, Enabled: enabled}
 	path := "/groups/" + url.PathEscape(name)
 	var out groupsEnvelope
@@ -78,10 +85,19 @@ func (c *Client) UpdateGroup(ctx context.Context, name, comment string, enabled 
 
 // DeleteGroup removes a group via DELETE /api/groups/{name}.
 func (c *Client) DeleteGroup(ctx context.Context, name string) error {
-	return c.do(ctx, http.MethodDelete, "/groups/"+url.PathEscape(name), nil, nil)
+	return c.do(
+		ctx,
+		http.MethodDelete,
+		"/groups/"+url.PathEscape(name),
+		nil,
+		nil,
+	)
 }
 
 // BatchDeleteGroups removes multiple groups via POST /api/groups:batchDelete.
-func (c *Client) BatchDeleteGroups(ctx context.Context, items []GroupRef) error {
+func (c *Client) BatchDeleteGroups(
+	ctx context.Context,
+	items []GroupRef,
+) error {
 	return c.do(ctx, http.MethodPost, "/groups:batchDelete", items, nil)
 }

--- a/internal/pihole/groups_test.go
+++ b/internal/pihole/groups_test.go
@@ -13,7 +13,11 @@ func TestGroupsListDecodes(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != "/api/groups" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"groups":[{"name":"kids","comment":"c","enabled":true,"id":2}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"groups":[{"name":"kids","comment":"c","enabled":true,"id":2}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -34,7 +38,11 @@ func TestAddGroupPostsBody(t *testing.T) {
 		}
 		data, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(data, &gotBody)
-		writeJSON(w, http.StatusCreated, `{"groups":[{"name":"kids","enabled":true,"id":5}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusCreated,
+			`{"groups":[{"name":"kids","enabled":true,"id":5}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -45,7 +53,8 @@ func TestAddGroupPostsBody(t *testing.T) {
 	if got.ID != 5 {
 		t.Errorf("got id = %d, want 5", got.ID)
 	}
-	if gotBody.Name != "kids" || gotBody.Comment != "family" || !gotBody.Enabled {
+	if gotBody.Name != "kids" || gotBody.Comment != "family" ||
+		!gotBody.Enabled {
 		t.Errorf("body = %+v, want name=kids comment=family enabled", gotBody)
 	}
 }
@@ -58,7 +67,11 @@ func TestUpdateGroupPutsToNamePath(t *testing.T) {
 		}
 		data, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(data, &gotBody)
-		writeJSON(w, http.StatusOK, `{"groups":[{"name":"kids","enabled":false,"id":5}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"groups":[{"name":"kids","enabled":false,"id":5}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -100,7 +113,10 @@ func TestBatchDeleteGroupsSendsItemBody(t *testing.T) {
 	})
 	client.setSID("S")
 
-	err := client.BatchDeleteGroups(context.Background(), []GroupRef{{Item: "kids"}})
+	err := client.BatchDeleteGroups(
+		context.Background(),
+		[]GroupRef{{Item: "kids"}},
+	)
 	if err != nil {
 		t.Fatalf("BatchDeleteGroups error: %v", err)
 	}

--- a/internal/pihole/history.go
+++ b/internal/pihole/history.go
@@ -17,7 +17,10 @@ func (c *Client) History(ctx context.Context) (History, error) {
 
 // HistoryClients fetches GET /api/history/clients?N — per-client over-time
 // buckets for the top n clients. n <= 0 omits the parameter (server default).
-func (c *Client) HistoryClients(ctx context.Context, n int) (HistoryClients, error) {
+func (c *Client) HistoryClients(
+	ctx context.Context,
+	n int,
+) (HistoryClients, error) {
 	var out HistoryClients
 	path := "/history/clients"
 	if n > 0 {

--- a/internal/pihole/history_test.go
+++ b/internal/pihole/history_test.go
@@ -11,8 +11,11 @@ func TestHistory(t *testing.T) {
 		if r.URL.Path != "/api/history" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"history":[{"timestamp":1000,"total":10,"cached":3,"blocked":2,"forwarded":5}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"history":[{"timestamp":1000,"total":10,"cached":3,"blocked":2,"forwarded":5}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -20,7 +23,8 @@ func TestHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("History error: %v", err)
 	}
-	if len(got.History) != 1 || got.History[0].Total != 10 || got.History[0].Blocked != 2 {
+	if len(got.History) != 1 || got.History[0].Total != 10 ||
+		got.History[0].Blocked != 2 {
 		t.Errorf("history = %+v", got.History)
 	}
 }
@@ -29,8 +33,11 @@ func TestHistoryClientsBuildsNParam(t *testing.T) {
 	var gotQuery string
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.RawQuery
-		writeJSON(w, http.StatusOK,
-			`{"clients":{"10.0.0.1":{"name":"host","total":9}},"history":[{"timestamp":1000,"data":{"10.0.0.1":9}}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"clients":{"10.0.0.1":{"name":"host","total":9}},"history":[{"timestamp":1000,"data":{"10.0.0.1":9}}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/info.go
+++ b/internal/pihole/info.go
@@ -37,7 +37,10 @@ type DNSLogPage struct {
 // ftl|host|system|version|metrics|sensors|database|messages. The section object
 // is returned as an open-ended tree (its top-level key mirrors the section
 // name).
-func (c *Client) Info(ctx context.Context, section string) (map[string]any, error) {
+func (c *Client) Info(
+	ctx context.Context,
+	section string,
+) (map[string]any, error) {
 	path := "/info/" + section
 	var raw map[string]any
 	if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {

--- a/internal/pihole/info_test.go
+++ b/internal/pihole/info_test.go
@@ -12,7 +12,11 @@ func TestInfoSectionDecode(t *testing.T) {
 		if r.URL.Path != "/api/info/ftl" {
 			t.Errorf("path = %q, want /api/info/ftl", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK, `{"ftl":{"privacy_level":0,"pid":1234},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"ftl":{"privacy_level":0,"pid":1234},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -52,8 +56,11 @@ func TestMessagesDecode(t *testing.T) {
 		if r.URL.Path != "/api/info/messages" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"messages":[{"id":7,"timestamp":1700000000.5,"type":"REGEX","plain":"bad regex","html":"<b>bad</b>","url":"http://x"}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"messages":[{"id":7,"timestamp":1700000000.5,"type":"REGEX","plain":"bad regex","html":"<b>bad</b>","url":"http://x"}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -67,7 +74,14 @@ func TestMessagesDecode(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("len = %d, want 1", len(msgs))
 	}
-	want := DiagnosisMessage{ID: 7, Timestamp: 1700000000.5, Type: "REGEX", Plain: "bad regex", HTML: "<b>bad</b>", URL: "http://x"}
+	want := DiagnosisMessage{
+		ID:        7,
+		Timestamp: 1700000000.5,
+		Type:      "REGEX",
+		Plain:     "bad regex",
+		HTML:      "<b>bad</b>",
+		URL:       "http://x",
+	}
 	if msgs[0] != want {
 		t.Errorf("msg = %#v, want %#v", msgs[0], want)
 	}
@@ -123,8 +137,11 @@ func TestDNSLogWithNextID(t *testing.T) {
 		if got := r.URL.Query().Get("nextID"); got != "42" {
 			t.Errorf("nextID = %q, want 42", got)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"log":[{"timestamp":1700000000.0,"message":"query A","prio":"info"}],"nextID":43}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"log":[{"timestamp":1700000000.0,"message":"query A","prio":"info"}],"nextID":43}`,
+		)
 	})
 	client.setSID("S")
 
@@ -138,7 +155,8 @@ func TestDNSLogWithNextID(t *testing.T) {
 	if page.NextID != 43 {
 		t.Errorf("nextID = %d, want 43", page.NextID)
 	}
-	if len(page.Log) != 1 || page.Log[0].Message != "query A" || page.Log[0].PRIO != "info" {
+	if len(page.Log) != 1 || page.Log[0].Message != "query A" ||
+		page.Log[0].PRIO != "info" {
 		t.Errorf("log = %#v", page.Log)
 	}
 }

--- a/internal/pihole/lists.go
+++ b/internal/pihole/lists.go
@@ -72,8 +72,20 @@ func (c *Client) Lists(ctx context.Context, listType ListType) ([]List, error) {
 }
 
 // AddList creates a list via POST /api/lists. The new list is enabled.
-func (c *Client) AddList(ctx context.Context, address string, listType ListType, comment string, groups []int) (List, error) {
-	body := listCreateRequest{Address: address, Type: listType, Comment: comment, Groups: groups, Enabled: true}
+func (c *Client) AddList(
+	ctx context.Context,
+	address string,
+	listType ListType,
+	comment string,
+	groups []int,
+) (List, error) {
+	body := listCreateRequest{
+		Address: address,
+		Type:    listType,
+		Comment: comment,
+		Groups:  groups,
+		Enabled: true,
+	}
 	var out listsEnvelope
 	if err := c.do(ctx, http.MethodPost, "/lists", body, &out); err != nil {
 		return List{}, err
@@ -85,9 +97,25 @@ func (c *Client) AddList(ctx context.Context, address string, listType ListType,
 }
 
 // UpdateList updates a list via PUT /api/lists/{address}?type={listType}.
-func (c *Client) UpdateList(ctx context.Context, address string, listType ListType, comment string, groups []int, enabled bool) (List, error) {
-	body := listUpdateRequest{Type: listType, Comment: comment, Groups: groups, Enabled: enabled}
-	path := "/lists/" + url.PathEscape(address) + "?type=" + url.QueryEscape(string(listType))
+func (c *Client) UpdateList(
+	ctx context.Context,
+	address string,
+	listType ListType,
+	comment string,
+	groups []int,
+	enabled bool,
+) (List, error) {
+	body := listUpdateRequest{
+		Type:    listType,
+		Comment: comment,
+		Groups:  groups,
+		Enabled: enabled,
+	}
+	path := "/lists/" + url.PathEscape(
+		address,
+	) + "?type=" + url.QueryEscape(
+		string(listType),
+	)
 	var out listsEnvelope
 	if err := c.do(ctx, http.MethodPut, path, body, &out); err != nil {
 		return List{}, err
@@ -99,8 +127,16 @@ func (c *Client) UpdateList(ctx context.Context, address string, listType ListTy
 }
 
 // DeleteList removes a list via DELETE /api/lists/{address}?type={listType}.
-func (c *Client) DeleteList(ctx context.Context, address string, listType ListType) error {
-	path := "/lists/" + url.PathEscape(address) + "?type=" + url.QueryEscape(string(listType))
+func (c *Client) DeleteList(
+	ctx context.Context,
+	address string,
+	listType ListType,
+) error {
+	path := "/lists/" + url.PathEscape(
+		address,
+	) + "?type=" + url.QueryEscape(
+		string(listType),
+	)
 	return c.do(ctx, http.MethodDelete, path, nil, nil)
 }
 

--- a/internal/pihole/lists_test.go
+++ b/internal/pihole/lists_test.go
@@ -15,7 +15,11 @@ func TestListsSendsTypeParam(t *testing.T) {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		gotType = r.URL.Query().Get("type")
-		writeJSON(w, http.StatusOK, `{"lists":[{"address":"https://x/list.txt","type":"block","enabled":true,"id":4}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"lists":[{"address":"https://x/list.txt","type":"block","enabled":true,"id":4}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -26,7 +30,8 @@ func TestListsSendsTypeParam(t *testing.T) {
 	if gotType != "block" {
 		t.Errorf("type param = %q, want block", gotType)
 	}
-	if len(got) != 1 || got[0].Address != "https://x/list.txt" || got[0].ID != 4 {
+	if len(got) != 1 || got[0].Address != "https://x/list.txt" ||
+		got[0].ID != 4 {
 		t.Errorf("got = %+v, want one list id=4", got)
 	}
 }
@@ -39,18 +44,29 @@ func TestAddListPostsBody(t *testing.T) {
 		}
 		data, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(data, &gotBody)
-		writeJSON(w, http.StatusCreated, `{"lists":[{"address":"https://x/list.txt","type":"allow","id":6}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusCreated,
+			`{"lists":[{"address":"https://x/list.txt","type":"allow","id":6}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
-	got, err := client.AddList(context.Background(), "https://x/list.txt", ListAllow, "mine", []int{0})
+	got, err := client.AddList(
+		context.Background(),
+		"https://x/list.txt",
+		ListAllow,
+		"mine",
+		[]int{0},
+	)
 	if err != nil {
 		t.Fatalf("AddList error: %v", err)
 	}
 	if got.ID != 6 {
 		t.Errorf("got id = %d, want 6", got.ID)
 	}
-	if gotBody.Address != "https://x/list.txt" || gotBody.Type != ListAllow || !gotBody.Enabled {
+	if gotBody.Address != "https://x/list.txt" || gotBody.Type != ListAllow ||
+		!gotBody.Enabled {
 		t.Errorf("body = %+v, want address/type=allow/enabled", gotBody)
 	}
 }
@@ -58,15 +74,27 @@ func TestAddListPostsBody(t *testing.T) {
 func TestUpdateListPutsWithTypeParam(t *testing.T) {
 	var gotType string
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/api/lists/https://x/list.txt" {
+		if r.Method != http.MethodPut ||
+			r.URL.Path != "/api/lists/https://x/list.txt" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		gotType = r.URL.Query().Get("type")
-		writeJSON(w, http.StatusOK, `{"lists":[{"address":"https://x/list.txt","type":"block","enabled":false,"id":6}],"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"lists":[{"address":"https://x/list.txt","type":"block","enabled":false,"id":6}],"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
-	got, err := client.UpdateList(context.Background(), "https://x/list.txt", ListBlock, "c", nil, false)
+	got, err := client.UpdateList(
+		context.Background(),
+		"https://x/list.txt",
+		ListBlock,
+		"c",
+		nil,
+		false,
+	)
 	if err != nil {
 		t.Fatalf("UpdateList error: %v", err)
 	}
@@ -80,7 +108,8 @@ func TestUpdateListPutsWithTypeParam(t *testing.T) {
 
 func TestDeleteListReturns204(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete || r.URL.Path != "/api/lists/https://x/list.txt" {
+		if r.Method != http.MethodDelete ||
+			r.URL.Path != "/api/lists/https://x/list.txt" {
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
 		if r.URL.Query().Get("type") != "block" {
@@ -107,11 +136,15 @@ func TestBatchDeleteListsSendsItemBody(t *testing.T) {
 	})
 	client.setSID("S")
 
-	err := client.BatchDeleteLists(context.Background(), []ListRef{{Item: "https://x/list.txt", Type: ListBlock}})
+	err := client.BatchDeleteLists(
+		context.Background(),
+		[]ListRef{{Item: "https://x/list.txt", Type: ListBlock}},
+	)
 	if err != nil {
 		t.Fatalf("BatchDeleteLists error: %v", err)
 	}
-	if len(raw) != 1 || raw[0]["item"] != "https://x/list.txt" || raw[0]["type"] != "block" {
+	if len(raw) != 1 || raw[0]["item"] != "https://x/list.txt" ||
+		raw[0]["type"] != "block" {
 		t.Errorf("body = %+v, want [{item,type:block}]", raw)
 	}
 }

--- a/internal/pihole/network.go
+++ b/internal/pihole/network.go
@@ -58,7 +58,10 @@ func (c *Client) Routes(ctx context.Context) (map[string]any, error) {
 }
 
 // networkObject fetches a network endpoint that returns an open-ended object.
-func (c *Client) networkObject(ctx context.Context, path string) (map[string]any, error) {
+func (c *Client) networkObject(
+	ctx context.Context,
+	path string,
+) (map[string]any, error) {
 	var out map[string]any
 	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
 		return nil, err

--- a/internal/pihole/network_test.go
+++ b/internal/pihole/network_test.go
@@ -35,10 +35,14 @@ func TestNetworkDevicesDecode(t *testing.T) {
 	if d.ID != 1 || d.HWAddr != "aa:bb:cc:dd:ee:ff" || d.Interface != "eth0" {
 		t.Errorf("device = %#v", d)
 	}
-	if d.NumQueries != 42 || d.MACVendor != "Acme" || d.FirstSeen != 1700000000 || d.LastQuery != 1700000500 {
+	if d.NumQueries != 42 || d.MACVendor != "Acme" ||
+		d.FirstSeen != 1700000000 ||
+		d.LastQuery != 1700000500 {
 		t.Errorf("device = %#v", d)
 	}
-	if len(d.IPs) != 1 || d.IPs[0].IP != "192.168.1.5" || d.IPs[0].Name != "host.local" || d.IPs[0].LastSeen != 1700000400 {
+	if len(d.IPs) != 1 || d.IPs[0].IP != "192.168.1.5" ||
+		d.IPs[0].Name != "host.local" ||
+		d.IPs[0].LastSeen != 1700000400 {
 		t.Errorf("ips = %#v", d.IPs)
 	}
 }

--- a/internal/pihole/queries.go
+++ b/internal/pihole/queries.go
@@ -76,7 +76,10 @@ func (f QueryFilter) values() url.Values {
 
 // Queries fetches GET /api/queries with cursor pagination. Only the filter
 // fields that are set are included in the request.
-func (c *Client) Queries(ctx context.Context, filter QueryFilter) (QueriesPage, error) {
+func (c *Client) Queries(
+	ctx context.Context,
+	filter QueryFilter,
+) (QueriesPage, error) {
 	path := "/queries"
 	if q := filter.values().Encode(); q != "" {
 		path += "?" + q

--- a/internal/pihole/queries_test.go
+++ b/internal/pihole/queries_test.go
@@ -27,7 +27,11 @@ func TestQueryFilterValuesOnlySetFields(t *testing.T) {
 				Start:  ptr(100),
 				Cursor: ptr(int64(987654321)),
 			},
-			want: url.Values{"length": {"50"}, "start": {"100"}, "cursor": {"987654321"}},
+			want: url.Values{
+				"length": {"50"},
+				"start":  {"100"},
+				"cursor": {"987654321"},
+			},
 		},
 		{
 			name: "filters and time window",
@@ -47,7 +51,9 @@ func TestQueryFilterValuesOnlySetFields(t *testing.T) {
 			want: url.Values{
 				"from": {"1000"}, "until": {"2000"}, "domain": {"example.com"},
 				"client_ip": {"10.0.0.5"}, "client_name": {"laptop"},
-				"upstream": {"1.1.1.1#53"}, "type": {"A"}, "status": {"GRAVITY"},
+				"upstream": {
+					"1.1.1.1#53",
+				}, "type": {"A"}, "status": {"GRAVITY"},
 				"reply": {"IP"}, "dnssec": {"SECURE"}, "disk": {"true"},
 			},
 		},
@@ -73,13 +79,19 @@ func TestQueriesRoundTrip(t *testing.T) {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		gotQuery = r.URL.RawQuery
-		writeJSON(w, http.StatusOK,
-			`{"queries":[{"id":1,"time":123.4,"type":"A","domain":"example.com","status":"FORWARDED","client":{"ip":"10.0.0.5","name":"laptop"},"reply":{"type":"IP","time":1.2},"upstream":"1.1.1.1#53"}],"cursor":42,"recordsFiltered":1,"recordsTotal":500,"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"queries":[{"id":1,"time":123.4,"type":"A","domain":"example.com","status":"FORWARDED","client":{"ip":"10.0.0.5","name":"laptop"},"reply":{"type":"IP","time":1.2},"upstream":"1.1.1.1#53"}],"cursor":42,"recordsFiltered":1,"recordsTotal":500,"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
 	// Act
-	page, err := client.Queries(context.Background(), QueryFilter{Length: ptr(1), Domain: ptr("example.com")})
+	page, err := client.Queries(
+		context.Background(),
+		QueryFilter{Length: ptr(1), Domain: ptr("example.com")},
+	)
 
 	// Assert
 	if err != nil {

--- a/internal/pihole/stats.go
+++ b/internal/pihole/stats.go
@@ -36,7 +36,11 @@ func (c *Client) QueryTypes(ctx context.Context) (QueryTypes, error) {
 
 // TopDomains fetches GET /api/stats/top_domains with the blocked and count
 // query parameters.
-func (c *Client) TopDomains(ctx context.Context, blocked bool, count int) (TopDomains, error) {
+func (c *Client) TopDomains(
+	ctx context.Context,
+	blocked bool,
+	count int,
+) (TopDomains, error) {
 	var out TopDomains
 	path := "/stats/top_domains" + topQuery(blocked, count)
 	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
@@ -47,7 +51,11 @@ func (c *Client) TopDomains(ctx context.Context, blocked bool, count int) (TopDo
 
 // TopClients fetches GET /api/stats/top_clients with the blocked and count
 // query parameters.
-func (c *Client) TopClients(ctx context.Context, blocked bool, count int) (TopClients, error) {
+func (c *Client) TopClients(
+	ctx context.Context,
+	blocked bool,
+	count int,
+) (TopClients, error) {
 	var out TopClients
 	path := "/stats/top_clients" + topQuery(blocked, count)
 	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
@@ -58,7 +66,10 @@ func (c *Client) TopClients(ctx context.Context, blocked bool, count int) (TopCl
 
 // RecentBlocked fetches GET /api/stats/recent_blocked. It returns the list of
 // most-recently blocked domain names.
-func (c *Client) RecentBlocked(ctx context.Context, count int) ([]string, error) {
+func (c *Client) RecentBlocked(
+	ctx context.Context,
+	count int,
+) ([]string, error) {
 	var out struct {
 		Blocked []string `json:"blocked"`
 		Took    float64  `json:"took"`

--- a/internal/pihole/stats_test.go
+++ b/internal/pihole/stats_test.go
@@ -12,8 +12,11 @@ func TestSummary(t *testing.T) {
 		if r.URL.Path != "/api/stats/summary" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"queries":{"total":100,"blocked":25,"percent_blocked":25.0,"unique_domains":40},"clients":{"active":5,"total":8},"gravity":{"domains_being_blocked":1000},"took":0.1}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"queries":{"total":100,"blocked":25,"percent_blocked":25.0,"unique_domains":40},"clients":{"active":5,"total":8},"gravity":{"domains_being_blocked":1000},"took":0.1}`,
+		)
 	})
 	client.setSID("S")
 
@@ -34,8 +37,11 @@ func TestSummary(t *testing.T) {
 
 func TestUpstreams(t *testing.T) {
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK,
-			`{"upstreams":[{"ip":"1.1.1.1","name":"cloudflare","port":53,"count":42}],"forwarded_queries":42,"total_queries":100,"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"upstreams":[{"ip":"1.1.1.1","name":"cloudflare","port":53,"count":42}],"forwarded_queries":42,"total_queries":100,"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -43,7 +49,8 @@ func TestUpstreams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Upstreams error: %v", err)
 	}
-	if len(got.Upstreams) != 1 || got.Upstreams[0].IP != "1.1.1.1" || got.Upstreams[0].Count != 42 {
+	if len(got.Upstreams) != 1 || got.Upstreams[0].IP != "1.1.1.1" ||
+		got.Upstreams[0].Count != 42 {
 		t.Errorf("upstreams = %+v", got.Upstreams)
 	}
 }
@@ -68,8 +75,11 @@ func TestTopDomainsBuildsBlockedAndCountParams(t *testing.T) {
 	var gotQuery string
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.RawQuery
-		writeJSON(w, http.StatusOK,
-			`{"domains":[{"domain":"ads.example","count":9}],"total_queries":100,"blocked_queries":9,"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"domains":[{"domain":"ads.example","count":9}],"total_queries":100,"blocked_queries":9,"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -92,8 +102,11 @@ func TestTopClientsOmitsCountWhenZero(t *testing.T) {
 	var gotQuery string
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
 		gotQuery = r.URL.RawQuery
-		writeJSON(w, http.StatusOK,
-			`{"clients":[{"ip":"10.0.0.5","name":"laptop","count":50}],"total_queries":100,"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"clients":[{"ip":"10.0.0.5","name":"laptop","count":50}],"total_queries":100,"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/system_test.go
+++ b/internal/pihole/system_test.go
@@ -53,26 +53,41 @@ func TestSystemDecodesNestedMetrics(t *testing.T) {
 		t.Errorf("cpu%% = %.3f, want ~0.9", got.CPUPercent)
 	}
 	if got.Load1Percent < 2.47 || got.Load1Percent > 2.48 {
-		t.Errorf("load1%% = %.3f, want ~2.478 (first load bucket)", got.Load1Percent)
+		t.Errorf(
+			"load1%% = %.3f, want ~2.478 (first load bucket)",
+			got.Load1Percent,
+		)
 	}
 	if got.MemUsedPercent < 6.78 || got.MemUsedPercent > 6.79 {
 		t.Errorf("mem%% = %.3f, want ~6.787", got.MemUsedPercent)
 	}
 	if got.MemUsedKiB != 263808 || got.MemTotalKiB != 3886904 {
-		t.Errorf("mem KiB = %d/%d, want 263808/3886904", got.MemUsedKiB, got.MemTotalKiB)
+		t.Errorf(
+			"mem KiB = %d/%d, want 263808/3886904",
+			got.MemUsedKiB,
+			got.MemTotalKiB,
+		)
 	}
 	if got.SwapUsedPercent != 0 {
 		t.Errorf("swap%% = %.3f, want 0", got.SwapUsedPercent)
 	}
 	if got.FTLCPUPercent < 0.14 || got.FTLMemPercent < 1.07 {
-		t.Errorf("ftl cpu/mem = %.3f/%.3f, want ~0.15/~1.08", got.FTLCPUPercent, got.FTLMemPercent)
+		t.Errorf(
+			"ftl cpu/mem = %.3f/%.3f, want ~0.15/~1.08",
+			got.FTLCPUPercent,
+			got.FTLMemPercent,
+		)
 	}
 }
 
 func TestSystemLoadDefaultsWhenAbsent(t *testing.T) {
 	// Arrange: a host with no load buckets must not panic on the empty slice.
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, `{"system":{"cpu":{"nprocs":2,"load":{"percent":[]}}},"took":0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"system":{"cpu":{"nprocs":2,"load":{"percent":[]}}},"took":0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -84,7 +99,10 @@ func TestSystemLoadDefaultsWhenAbsent(t *testing.T) {
 		t.Fatalf("System error: %v", err)
 	}
 	if got.Load1Percent != 0 {
-		t.Errorf("load1%% = %.3f, want 0 when load buckets are empty", got.Load1Percent)
+		t.Errorf(
+			"load1%% = %.3f, want 0 when load buckets are empty",
+			got.Load1Percent,
+		)
 	}
 }
 
@@ -94,8 +112,11 @@ func TestSensorsInfoDecodesTemperature(t *testing.T) {
 		if r.URL.Path != "/api/info/sensors" {
 			t.Errorf("path = %q, want /api/info/sensors", r.URL.Path)
 		}
-		writeJSON(w, http.StatusOK,
-			`{"sensors":{"list":[],"cpu_temp":48.199,"hot_limit":60,"unit":"C"},"took":0.0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"sensors":{"list":[],"cpu_temp":48.199,"hot_limit":60,"unit":"C"},"took":0.0}`,
+		)
 	})
 	client.setSID("S")
 
@@ -120,7 +141,11 @@ func TestSensorsInfoDecodesTemperature(t *testing.T) {
 func TestSensorsInfoNoTemperature(t *testing.T) {
 	// Arrange: a host with no CPU temperature sensor (cpu_temp null).
 	client, _ := mockFTL(t, func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, `{"sensors":{"list":[],"cpu_temp":null,"hot_limit":60,"unit":"C"},"took":0}`)
+		writeJSON(
+			w,
+			http.StatusOK,
+			`{"sensors":{"list":[],"cpu_temp":null,"hot_limit":60,"unit":"C"},"took":0}`,
+		)
 	})
 	client.setSID("S")
 

--- a/internal/pihole/testutil_test.go
+++ b/internal/pihole/testutil_test.go
@@ -9,7 +9,10 @@ import (
 // mockFTL spins up an httptest server whose handler is supplied by the test,
 // and returns a Client pointed at it. The client uses the test server's own
 // http.Client so TLS (for TLS servers) is trusted.
-func mockFTL(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+func mockFTL(
+	t *testing.T,
+	handler http.HandlerFunc,
+) (*Client, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
@@ -22,7 +25,11 @@ func mockFTL(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server)
 func authOK(w http.ResponseWriter, sid string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"session":{"valid":true,"sid":"` + sid + `","csrf":"c","validity":1800,"totp":false},"took":0.1}`))
+	_, _ = w.Write(
+		[]byte(
+			`{"session":{"valid":true,"sid":"` + sid + `","csrf":"c","validity":1800,"totp":false},"took":0.1}`,
+		),
+	)
 }
 
 // writeJSON is a small helper for handlers.

--- a/internal/pihole/types.go
+++ b/internal/pihole/types.go
@@ -44,7 +44,8 @@ type Summary struct {
 	Raw  json.RawMessage `json:"-"`
 }
 
-// UpstreamServer is a single upstream entry in an /api/stats/upstreams response.
+// UpstreamServer is a single upstream entry in an /api/stats/upstreams
+// response.
 type UpstreamServer struct {
 	IP         string `json:"ip"`
 	Name       string `json:"name"`

--- a/internal/theme/builtin.go
+++ b/internal/theme/builtin.go
@@ -1,30 +1,70 @@
 package theme
 
-import "charm.land/lipgloss/v2"
+import (
+	"image/color"
+
+	"charm.land/lipgloss/v2"
+)
 
 // Built-in theme names.
 const (
 	NameAuto          = "auto"
+	NameGloss         = "gloss"
 	NameDeepNight     = "deep-night"
 	NameLightLuxury   = "light-luxury"
 	NamePiholeClassic = "pihole-classic"
 )
 
 // Auto is the default theme. It commits to no single mode; instead it resolves
-// to DeepNight on a dark terminal or LightLuxury on a light one the moment the
+// to Gloss on a dark terminal or LightLuxury on a light one the moment the
 // background is known (a tea.BackgroundColorMsg drives Theme.Adapt). Before
-// detection it renders as DeepNight — the safe choice for the common dark
-// terminal, and the reason a light-terminal user never gets a wall of ivory.
+// detection it renders as Gloss — tihole's signature look and the safe choice
+// for the common dark terminal, so a light-terminal user never gets a wall of
+// ivory yet everyone else lands on the brand palette.
 func Auto() *Theme {
-	t := DeepNight()
+	t := Gloss()
 	t.Name = NameAuto
 	t.adapt = func(isDark bool) *Theme {
 		if isDark {
-			return DeepNight()
+			return Gloss()
 		}
 		return LightLuxury()
 	}
 	return t
+}
+
+// Gloss is tihole's signature dark theme, modeled on the Charm lipgloss
+// palette:
+// a hot-pink brand on a deep-void surface, with a purple→acid→cyan signature
+// ramp for the boot banner and wordmark. Luminous, glossy, and unmistakably the
+// default face of the app.
+func Gloss() *Theme {
+	return &Theme{
+		Name:    NameGloss,
+		Surface: lipgloss.Color("#0B0412"), // deep void
+		Panel: lipgloss.Color(
+			"#190A2E",
+		), // obsidian purple, raised off the void
+		Text:   lipgloss.Color("#F4F1FB"), // near-white with a violet cast
+		Subtle: lipgloss.Color("#9E8FC6"), // muted lavender
+		Accent: lipgloss.Color(
+			"#FF2E93",
+		), // hot pink — brand, focus, selection
+		Allow:  lipgloss.Color("#5CF07A"), // acid green — positive
+		Block:  lipgloss.Color("#FF4D6D"), // hot magenta-red — negative
+		Warn:   lipgloss.Color("#F5B93D"), // amber
+		Border: lipgloss.Color("#3A1E63"), // dim purple divider
+		// Stop order is tuned for a clean sweep: cyan bridges purple→acid so
+		// the
+		// blend never passes through muddy olive.
+		Ramp: []color.Color{
+			lipgloss.Color("#FF2E93"), // pink
+			lipgloss.Color("#E533C9"), // magenta
+			lipgloss.Color("#6B2FE0"), // purple
+			lipgloss.Color("#2EE6FF"), // cyan
+			lipgloss.Color("#D6FF2E"), // acid
+		},
+	}
 }
 
 // DeepNight is the signature dark theme: a deep midnight-navy surface with a
@@ -82,6 +122,7 @@ func PiholeClassic() *Theme {
 // return fresh pointers so callers can never mutate a shared instance.
 var builtinFactories = map[string]func() *Theme{
 	NameAuto:          Auto,
+	NameGloss:         Gloss,
 	NameDeepNight:     DeepNight,
 	NameLightLuxury:   LightLuxury,
 	NamePiholeClassic: PiholeClassic,
@@ -98,7 +139,14 @@ func Builtin(name string) (*Theme, bool) {
 }
 
 // Names returns the built-in theme names in a stable, display order. Auto leads
-// because it is the recommended default.
+// because it is the recommended default; Gloss follows as the signature look it
+// resolves to on a dark terminal.
 func Names() []string {
-	return []string{NameAuto, NameDeepNight, NameLightLuxury, NamePiholeClassic}
+	return []string{
+		NameAuto,
+		NameGloss,
+		NameDeepNight,
+		NameLightLuxury,
+		NamePiholeClassic,
+	}
 }

--- a/internal/theme/omarchy.go
+++ b/internal/theme/omarchy.go
@@ -52,13 +52,17 @@ func loadOmarchyFrom(dir string) (*Theme, error) {
 	bg := firstNonEmpty(primary["background"])
 	fg := firstNonEmpty(primary["foreground"])
 	if bg == "" || fg == "" {
-		return nil, fmt.Errorf("omarchy: %s missing [colors.primary] background/foreground", path)
+		return nil, fmt.Errorf(
+			"omarchy: %s missing [colors.primary] background/foreground",
+			path,
+		)
 	}
 
 	// light.mode marker beside the toml nudges derivation of ambiguous tokens.
 	isLight := fileExists(filepath.Join(dir, "light.mode"))
 
-	// Panel is a slight shift of Surface: lighter in dark mode, darker in light.
+	// Panel is a slight shift of Surface: lighter in dark mode, darker in
+	// light.
 	panelDelta := 0.06
 	borderDelta := 0.14
 	if isLight {
@@ -70,7 +74,12 @@ func loadOmarchyFrom(dir string) (*Theme, error) {
 	green := firstNonEmpty(normal["green"], bright["green"])
 	yellow := firstNonEmpty(normal["yellow"], bright["yellow"])
 	// A bright accent: prefer bright blue, then bright magenta, then normals.
-	accent := firstNonEmpty(bright["blue"], bright["magenta"], normal["blue"], normal["magenta"])
+	accent := firstNonEmpty(
+		bright["blue"],
+		bright["magenta"],
+		normal["blue"],
+		normal["magenta"],
+	)
 	// Border from a neutral ANSI: normal white or bright black, else derived.
 	border := firstNonEmpty(normal["white"], bright["black"])
 
@@ -246,5 +255,10 @@ func mix(a, b string, t float64) string {
 		return a
 	}
 	lerp := func(x, y int) int { return clamp8(x + int(float64(y-x)*t)) }
-	return fmt.Sprintf("#%02x%02x%02x", lerp(ar, br), lerp(ag, bg), lerp(ab, bb))
+	return fmt.Sprintf(
+		"#%02x%02x%02x",
+		lerp(ar, br),
+		lerp(ag, bg),
+		lerp(ab, bb),
+	)
 }

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -17,7 +17,8 @@ import (
 // (what lipgloss.Color returns) so themes can be built from hex strings, ANSI
 // indices, or adaptive pickers uniformly.
 type Theme struct {
-	// Name is the stable identifier used by Builtin/Resolve (e.g. "deep-night").
+	// Name is the stable identifier used by Builtin/Resolve (e.g.
+	// "deep-night").
 	Name string
 
 	Surface color.Color // app background
@@ -30,6 +31,13 @@ type Theme struct {
 	Warn    color.Color // caution (amber family)
 	Border  color.Color // panel & divider borders
 
+	// Ramp is an optional multi-stop signature gradient (the brand sweep used
+	// by the splash banner and wordmark). When it has fewer than two stops,
+	// gradient helpers fall back to a plain Accent→Allow blend, so single-hue
+	// themes need
+	// not set it. The Gloss theme fills it with its pink→purple→acid→cyan ramp.
+	Ramp []color.Color
+
 	// adapt, when non-nil, lets a theme return a mode-specific variant from
 	// Adapt(isDark). Built-in themes are committed to a single mode and leave
 	// this nil (Adapt returns the receiver unchanged).
@@ -41,6 +49,16 @@ func (t *Theme) SurfaceStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Foreground(t.Text).
 		Background(t.Surface)
+}
+
+// SurfaceWhitespace is the whitespace-fill option for lipgloss.Place: it paints
+// the space Place adds around centered content with the surface background.
+// Without it that fill sits after a styled reset and bleeds the terminal's own
+// background through as gray gaps.
+func (t *Theme) SurfaceWhitespace() lipgloss.WhitespaceOption {
+	return lipgloss.WithWhitespaceStyle(
+		lipgloss.NewStyle().Background(t.Surface),
+	)
 }
 
 // PanelStyle is a raised, bordered container built from Panel/Border/Text.
@@ -86,6 +104,16 @@ func (t *Theme) WarnStyle() lipgloss.Style {
 // BorderStyle renders a divider/border using the Border token.
 func (t *Theme) BorderStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(t.Border)
+}
+
+// GradientStops returns the theme's signature gradient stops: the multi-stop
+// Ramp when it defines at least two colors, otherwise a two-stop Accent→Allow
+// blend. Callers sweep text or banners across these to carry the brand look.
+func (t *Theme) GradientStops() []color.Color {
+	if len(t.Ramp) >= 2 {
+		return t.Ramp
+	}
+	return []color.Color{t.Accent, t.Allow}
 }
 
 // Adapt returns the theme variant appropriate for the given background.

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -69,7 +69,11 @@ func TestBuiltinReturnsFalseForUnknownName(t *testing.T) {
 	th, ok := Builtin("no-such-theme")
 
 	if ok || th != nil {
-		t.Errorf("expected (nil, false) for unknown theme, got (%v, %v)", th, ok)
+		t.Errorf(
+			"expected (nil, false) for unknown theme, got (%v, %v)",
+			th,
+			ok,
+		)
 	}
 }
 
@@ -80,12 +84,58 @@ func TestBuiltinReturnsFreshInstances(t *testing.T) {
 
 	// Assert: distinct pointers so callers cannot mutate a shared theme.
 	if a == b {
-		t.Error("expected Builtin to return fresh instances, got shared pointer")
+		t.Error(
+			"expected Builtin to return fresh instances, got shared pointer",
+		)
+	}
+}
+
+func TestGlossHasNonNilTokensAndName(t *testing.T) {
+	th := Gloss()
+
+	if th.Name != NameGloss {
+		t.Errorf("expected name %q, got %q", NameGloss, th.Name)
+	}
+	tokensNonNil(t, th)
+
+	// Gloss carries the signature multi-stop ramp; GradientStops must surface
+	// it.
+	if len(th.Ramp) < 2 {
+		t.Errorf(
+			"expected Gloss to define a multi-stop ramp, got %d stops",
+			len(th.Ramp),
+		)
+	}
+	if got := th.GradientStops(); len(got) != len(th.Ramp) {
+		t.Errorf(
+			"GradientStops should return the ramp (%d stops), got %d",
+			len(th.Ramp),
+			len(got),
+		)
+	}
+}
+
+func TestGradientStopsFallsBackToAccentAllow(t *testing.T) {
+	// A single-hue theme (no Ramp) falls back to a two-stop Accent→Allow blend.
+	th := DeepNight()
+	got := th.GradientStops()
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 fallback stops, got %d", len(got))
+	}
+	if got[0] != th.Accent || got[1] != th.Allow {
+		t.Errorf("expected [Accent, Allow] fallback, got %v", got)
 	}
 }
 
 func TestNamesListsAllBuiltinsInOrder(t *testing.T) {
-	want := []string{NameAuto, NameDeepNight, NameLightLuxury, NamePiholeClassic}
+	want := []string{
+		NameAuto,
+		NameGloss,
+		NameDeepNight,
+		NameLightLuxury,
+		NamePiholeClassic,
+	}
 
 	got := Names()
 
@@ -169,7 +219,10 @@ func TestPickChoosesByBackground(t *testing.T) {
 
 // writeOmarchyFixture writes a sample alacritty.toml (Tokyo Night palette) into
 // dir and returns the known-good hex values for assertions.
-func writeOmarchyFixture(t *testing.T, dir string) (bg, fg, red, green, yellow, brightBlue string) {
+func writeOmarchyFixture(
+	t *testing.T,
+	dir string,
+) (bg, fg, red, green, yellow, brightBlue string) {
 	t.Helper()
 	bg, fg = "#1a1b26", "#c0caf5"
 	red, green, yellow = "#f7768e", "#9ece6a", "#e0af68"
@@ -248,7 +301,9 @@ func TestLoadOmarchyMapsAnsiToSemanticTokens(t *testing.T) {
 	}
 	// Panel must be derived (a shift of Surface), not equal to Surface.
 	if colorHex(th.Panel) == bg {
-		t.Error("expected Panel to be a derived shift of Surface, not identical")
+		t.Error(
+			"expected Panel to be a derived shift of Surface, not identical",
+		)
 	}
 }
 
@@ -356,12 +411,18 @@ func TestAutoAdaptsToBackground(t *testing.T) {
 	}
 	tokensNonNil(t, th)
 
-	// Act / Assert: Adapt resolves to a concrete single-mode theme per background.
-	if got := th.Adapt(true); got.Name != NameDeepNight {
-		t.Errorf("dark background: expected %q, got %q", NameDeepNight, got.Name)
+	// Act / Assert: Adapt resolves to a concrete single-mode theme per
+	// background.
+	// Dark terminals land on Gloss, tihole's signature default look.
+	if got := th.Adapt(true); got.Name != NameGloss {
+		t.Errorf("dark background: expected %q, got %q", NameGloss, got.Name)
 	}
 	if got := th.Adapt(false); got.Name != NameLightLuxury {
-		t.Errorf("light background: expected %q, got %q", NameLightLuxury, got.Name)
+		t.Errorf(
+			"light background: expected %q, got %q",
+			NameLightLuxury,
+			got.Name,
+		)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -85,7 +85,12 @@ type AppModel struct {
 
 // New builds the root model from a validated config and an authenticated
 // client for the active instance.
-func New(cfg *config.Config, cfgPath string, api *pihole.Client, th *theme.Theme) *AppModel {
+func New(
+	cfg *config.Config,
+	cfgPath string,
+	api *pihole.Client,
+	th *theme.Theme,
+) *AppModel {
 	ctx := &core.AppContext{
 		API:          api,
 		Theme:        th,
@@ -148,7 +153,10 @@ func (m *AppModel) Init() tea.Cmd {
 func (m *AppModel) splashCmd() tea.Cmd {
 	return tea.Batch(
 		m.splash.Tick,
-		tea.Tick(splashDuration, func(time.Time) tea.Msg { return splashDoneMsg{} }),
+		tea.Tick(
+			splashDuration,
+			func(time.Time) tea.Msg { return splashDoneMsg{} },
+		),
 	)
 }
 
@@ -199,7 +207,8 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// While the active screen is capturing text input (an editable field is
-		// focused), deliver keys straight to it so typed letters aren't stolen by
+		// focused), deliver keys straight to it so typed letters aren't stolen
+		// by
 		// global single-key shortcuts. ctrl+c still always quits.
 		if m.capturingInput() && msg.String() != "ctrl+c" {
 			break
@@ -255,7 +264,8 @@ func (m *AppModel) capturingInput() bool {
 	return ok && ic.CapturesInput()
 }
 
-// activeInteractive reports whether the active screen has actionable content the
+// activeInteractive reports whether the active screen has actionable content
+// the
 // rail should be able to descend into (see core.PanelInteractor). Screens that
 // don't implement the interface default to interactive.
 func (m *AppModel) activeInteractive() bool {
@@ -270,7 +280,8 @@ func (m *AppModel) activeInteractive() bool {
 func (m *AppModel) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
 	k := m.ctx.Keys
 	// Truly global: alive in both zones. Kept deliberately small — quit, help,
-	// palette, and the two app-level actions (blocking, instance) that no screen
+	// palette, and the two app-level actions (blocking, instance) that no
+	// screen
 	// binds. Everything else is zone-scoped so screen keys are never ambushed.
 	switch {
 	case key.Matches(msg, k.Quit):
@@ -309,10 +320,13 @@ func (m *AppModel) handleNavKey(msg tea.KeyPressMsg) tea.Cmd {
 		return m.switchPage(m.relPage(-1))
 	case key.Matches(msg, k.Down):
 		return m.switchPage(m.relPage(1))
-	case key.Matches(msg, k.Enter), key.Matches(msg, k.Right), msg.String() == "tab":
-		// Only descend into screens that have something to do. A read-only screen
-		// (e.g. the dashboard) opts out via core.PanelInteractor, so focus stays on
-		// the rail instead of trapping the user in a panel where no key responds.
+	case key.Matches(msg, k.Enter),
+		key.Matches(msg, k.Right),
+		msg.String() == "tab":
+		// Only descend into screens that have something to do. A read-only
+		// screen (e.g. the dashboard) opts out via core.PanelInteractor, so
+		// focus stays on the rail instead of trapping the user in a panel where
+		// no key responds.
 		if m.activeInteractive() {
 			m.focus = focusPanel
 		}
@@ -320,7 +334,8 @@ func (m *AppModel) handleNavKey(msg tea.KeyPressMsg) tea.Cmd {
 	case key.Matches(msg, k.Refresh):
 		return m.screens[m.active].Focus()
 	}
-	// Digit keys 1..9 quick-jump to a page, staying on the rail for fast browsing.
+	// Digit keys 1..9 quick-jump to a page, staying on the rail for fast
+	// browsing.
 	if d := msg.String(); len(d) == 1 && d[0] >= '1' && d[0] <= '9' {
 		idx := int(d[0] - '1')
 		order := core.PageOrder()
@@ -433,12 +448,33 @@ func (m *AppModel) paletteCommands() []components.Command {
 		})
 	}
 
-	cmds = append(cmds,
-		components.Command{Title: "Toggle blocking", Desc: "enable / disable", Run: m.toggleBlocking()},
-		components.Command{Title: "Disable blocking 30s", Desc: "temporary", Run: m.setBlockingFor(30)},
-		components.Command{Title: "Disable blocking 5m", Desc: "temporary", Run: m.setBlockingFor(300)},
-		components.Command{Title: "Disable blocking 30m", Desc: "temporary", Run: m.setBlockingFor(1800)},
-		components.Command{Title: "Disable blocking (until enabled)", Desc: "indefinite", Run: m.setBlockingFor(0)},
+	cmds = append(
+		cmds,
+		components.Command{
+			Title: "Toggle blocking",
+			Desc:  "enable / disable",
+			Run:   m.toggleBlocking(),
+		},
+		components.Command{
+			Title: "Disable blocking 30s",
+			Desc:  "temporary",
+			Run:   m.setBlockingFor(30),
+		},
+		components.Command{
+			Title: "Disable blocking 5m",
+			Desc:  "temporary",
+			Run:   m.setBlockingFor(300),
+		},
+		components.Command{
+			Title: "Disable blocking 30m",
+			Desc:  "temporary",
+			Run:   m.setBlockingFor(1800),
+		},
+		components.Command{
+			Title: "Disable blocking (until enabled)",
+			Desc:  "indefinite",
+			Run:   m.setBlockingFor(0),
+		},
 	)
 
 	for _, inst := range m.cfg.Instances {
@@ -494,7 +530,8 @@ func themeCmd(name string) tea.Cmd {
 	}
 }
 
-// nextInstance returns the name of the instance after the active one (wrapping).
+// nextInstance returns the name of the instance after the active one
+// (wrapping).
 func (m *AppModel) nextInstance() string {
 	insts := m.cfg.Instances
 	if len(insts) < 2 {
@@ -549,12 +586,14 @@ func (m *AppModel) applyInstancesChange(cfg *config.Config) tea.Cmd {
 
 // View composes the full screen: status bar, sidebar+content, help bar.
 func (m *AppModel) View() tea.View {
+	th := m.ctx.Theme
+
 	if m.width == 0 || m.height == 0 {
 		v := tea.NewView("")
 		v.AltScreen = true
+		v.BackgroundColor = th.Surface
 		return v
 	}
-	th := m.ctx.Theme
 
 	if m.booting {
 		splash := components.Splash{
@@ -565,6 +604,7 @@ func (m *AppModel) View() tea.View {
 		}.Render(th)
 		v := tea.NewView(splash)
 		v.AltScreen = true
+		v.BackgroundColor = th.Surface
 		return v
 	}
 
@@ -590,7 +630,13 @@ func (m *AppModel) View() tea.View {
 		middle = m.palette.Render(th, m.width, ch)
 	case m.showHelp:
 		// The help cheat-sheet overlays the body area.
-		middle = components.HelpSheet{Sections: m.helpSections()}.Render(th, m.width, ch)
+		middle = components.HelpSheet{
+			Sections: m.helpSections(),
+		}.Render(
+			th,
+			m.width,
+			ch,
+		)
 	default:
 		content := m.screens[m.active].View().Content
 		middle = lipgloss.JoinHorizontal(lipgloss.Top, sidebar, content)
@@ -606,6 +652,11 @@ func (m *AppModel) View() tea.View {
 	full = th.SurfaceStyle().Width(m.width).Height(m.height).Render(full)
 	v := tea.NewView(full)
 	v.AltScreen = true
+	// Paint the terminal's default background with the theme surface so any
+	// cell the app doesn't explicitly colour — table padding, gaps between
+	// composed blocks — falls back to the surface instead of leaking the
+	// terminal's own background (a solid colour or a background image) through.
+	v.BackgroundColor = th.Surface
 	return v
 }
 
@@ -619,7 +670,10 @@ func (m *AppModel) helpSections() []components.HelpSection {
 		if h.Key == "" && h.Desc == "" {
 			continue
 		}
-		global.Keys = append(global.Keys, components.HelpKey{Key: h.Key, Desc: h.Desc})
+		global.Keys = append(
+			global.Keys,
+			components.HelpKey{Key: h.Key, Desc: h.Desc},
+		)
 	}
 
 	screen := components.HelpSection{Title: m.screens[m.active].Title()}
@@ -628,7 +682,10 @@ func (m *AppModel) helpSections() []components.HelpSection {
 		if h.Key == "" && h.Desc == "" {
 			continue
 		}
-		screen.Keys = append(screen.Keys, components.HelpKey{Key: h.Key, Desc: h.Desc})
+		screen.Keys = append(
+			screen.Keys,
+			components.HelpKey{Key: h.Key, Desc: h.Desc},
+		)
 	}
 
 	sections := []components.HelpSection{global}
@@ -642,7 +699,9 @@ func (m *AppModel) helpSections() []components.HelpSection {
 func (m *AppModel) helpBar(width int) string {
 	th := m.ctx.Theme
 	if m.err != "" {
-		return th.BlockStyle().Width(width).Render("⚠ " + m.err + "  (esc/r to retry)")
+		return th.BlockStyle().
+			Width(width).
+			Render("⚠ " + m.err + "  (esc/r to retry)")
 	}
 	bindings := m.ctx.Keys.ShortHelp()
 	bindings = append(bindings, m.screens[m.active].Help()...)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -38,10 +38,19 @@ const (
 	// splashDuration is how long the ASCII boot screen lingers before the
 	// dashboard reveals. Any key dismisses it sooner.
 	splashDuration = 1600 * time.Millisecond
+
+	// blockPollInterval is how often the root re-fetches blocking status so the
+	// always-on top-bar pill reflects external changes (a toggle from the web
+	// UI, an expiring temporary-disable timer) without the user acting.
+	blockPollInterval = 10 * time.Second
 )
 
 // splashDoneMsg fires when the boot splash's timer elapses.
 type splashDoneMsg struct{}
+
+// blockPollMsg is the recurring tick that drives a background blocking
+// re-fetch.
+type blockPollMsg struct{}
 
 // blockingResultMsg carries a fresh blocking status.
 type blockingResultMsg struct{ status pihole.BlockingStatus }
@@ -144,6 +153,7 @@ func (m *AppModel) Init() tea.Cmd {
 		tea.RequestBackgroundColor, // drives the auto theme's light/dark choice
 		m.screens[m.active].Focus(),
 		fetchBlocking(m.ctx.API),
+		blockPollCmd(),
 		m.splashCmd(),
 	)
 }
@@ -237,6 +247,12 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.block.CountdownSecs = int(*st.Timer)
 		}
 		return m, nil
+
+	case blockPollMsg:
+		// Re-fetch in the background and reschedule the next tick. The pill
+		// keeps
+		// showing the last-known state until the fetch resolves.
+		return m, tea.Batch(fetchBlocking(m.ctx.API), blockPollCmd())
 
 	case blockingErrMsg:
 		m.err = msg.err.Error()
@@ -614,6 +630,7 @@ func (m *AppModel) View() tea.View {
 		Instance:   m.ctx.InstanceName,
 		ScreenName: m.screens[m.active].Title(),
 		Width:      m.width,
+		Blocking:   m.block,
 	}.Render(th)
 
 	sidebar := components.Sidebar{
@@ -707,6 +724,14 @@ func (m *AppModel) helpBar(width int) string {
 	bindings = append(bindings, m.screens[m.active].Help()...)
 	view := m.help.ShortHelpView(bindings)
 	return lipgloss.NewStyle().Width(width).Background(th.Panel).Render(view)
+}
+
+// blockPollCmd schedules the next background blocking re-fetch tick.
+func blockPollCmd() tea.Cmd {
+	return tea.Tick(
+		blockPollInterval,
+		func(time.Time) tea.Msg { return blockPollMsg{} },
+	)
 }
 
 // fetchBlocking loads the current blocking status.

--- a/internal/tui/app_input_capture_test.go
+++ b/internal/tui/app_input_capture_test.go
@@ -55,10 +55,16 @@ func TestCapturingScreenReceivesGlobalShortcutKeys(t *testing.T) {
 		t.Fatalf("capturing screen should receive 's', got %q", stub.lastKey)
 	}
 	if m.ctx.InstanceName != "home" {
-		t.Fatalf("switch-instance must not fire while capturing, instance=%q", m.ctx.InstanceName)
+		t.Fatalf(
+			"switch-instance must not fire while capturing, instance=%q",
+			m.ctx.InstanceName,
+		)
 	}
 	if m.active != activeBefore {
-		t.Fatalf("navigation must not fire while capturing, active=%v", m.active)
+		t.Fatalf(
+			"navigation must not fire while capturing, active=%v",
+			m.active,
+		)
 	}
 }
 
@@ -79,14 +85,24 @@ func TestCapturingScreenDoesNotFireQuitOrNav(t *testing.T) {
 		updated, cmd := m.Update(keyPress(tc.str, tc.r))
 		m = updated.(*AppModel)
 		if cmd != nil {
-			t.Fatalf("key %q must not produce a global command while capturing", tc.str)
+			t.Fatalf(
+				"key %q must not produce a global command while capturing",
+				tc.str,
+			)
 		}
 		if stub.lastKey != tc.str {
-			t.Fatalf("key %q should reach the screen, got %q", tc.str, stub.lastKey)
+			t.Fatalf(
+				"key %q should reach the screen, got %q",
+				tc.str,
+				stub.lastKey,
+			)
 		}
 	}
 	if m.active != core.PageDashboard {
-		t.Fatalf("no navigation should occur while capturing, active=%v", m.active)
+		t.Fatalf(
+			"no navigation should occur while capturing, active=%v",
+			m.active,
+		)
 	}
 }
 
@@ -110,6 +126,9 @@ func TestNonCapturingScreenFiresGlobalShortcut(t *testing.T) {
 
 	order := core.PageOrder()
 	if m.active != order[1].ID {
-		t.Fatalf("digit shortcut should navigate when not capturing, active=%v", m.active)
+		t.Fatalf(
+			"digit shortcut should navigate when not capturing, active=%v",
+			m.active,
+		)
 	}
 }

--- a/internal/tui/app_more_test.go
+++ b/internal/tui/app_more_test.go
@@ -118,7 +118,10 @@ func TestPanelFocusDelegatesNonEscToScreen(t *testing.T) {
 
 	// Assert
 	if m.active != before {
-		t.Fatalf("panel focus must not honor digit page-jumps, moved to %v", m.active)
+		t.Fatalf(
+			"panel focus must not honor digit page-jumps, moved to %v",
+			m.active,
+		)
 	}
 	if m.focus != focusPanel {
 		t.Fatalf("expected to remain in panel focus, got %v", m.focus)
@@ -136,7 +139,11 @@ func TestSetThemeMsgSwapsTheme(t *testing.T) {
 	m = updated.(*AppModel)
 
 	if m.ctx.Theme.Name != theme.NameLightLuxury {
-		t.Fatalf("expected theme %q, got %q", theme.NameLightLuxury, m.ctx.Theme.Name)
+		t.Fatalf(
+			"expected theme %q, got %q",
+			theme.NameLightLuxury,
+			m.ctx.Theme.Name,
+		)
 	}
 }
 
@@ -178,7 +185,11 @@ func TestBlockingResultWithTimerSetsCountdown(t *testing.T) {
 	m := sized(t, newTestModel(t), 120, 36)
 	secs := 42.0
 
-	updated, _ := m.Update(blockingResultMsg{status: pihole.BlockingStatus{Blocking: false, Timer: &secs}})
+	updated, _ := m.Update(
+		blockingResultMsg{
+			status: pihole.BlockingStatus{Blocking: false, Timer: &secs},
+		},
+	)
 	m = updated.(*AppModel)
 
 	if !m.block.Known {
@@ -196,9 +207,24 @@ func TestSwitchInstanceMsgSurvivesConfigChange(t *testing.T) {
 	cfg2 := &config.Config{
 		Active: "home",
 		Instances: []config.Instance{
-			{Name: "home", URL: "http://192.168.1.2", Password: "pw", VerifyTLS: &verify},
-			{Name: "office", URL: "http://10.0.0.2", Password: "pw2", VerifyTLS: &verify},
-			{Name: "cabin", URL: "http://10.0.0.3", Password: "pw3", VerifyTLS: &verify},
+			{
+				Name:      "home",
+				URL:       "http://192.168.1.2",
+				Password:  "pw",
+				VerifyTLS: &verify,
+			},
+			{
+				Name:      "office",
+				URL:       "http://10.0.0.2",
+				Password:  "pw2",
+				VerifyTLS: &verify,
+			},
+			{
+				Name:      "cabin",
+				URL:       "http://10.0.0.3",
+				Password:  "pw3",
+				VerifyTLS: &verify,
+			},
 		},
 	}
 
@@ -209,7 +235,10 @@ func TestSwitchInstanceMsgSurvivesConfigChange(t *testing.T) {
 		t.Fatal("config should be swapped in")
 	}
 	if m.ctx.InstanceName != "home" {
-		t.Fatalf("active instance should remain home, got %q", m.ctx.InstanceName)
+		t.Fatalf(
+			"active instance should remain home, got %q",
+			m.ctx.InstanceName,
+		)
 	}
 	if cmd != nil {
 		t.Fatal("surviving active instance should not trigger a switch cmd")
@@ -245,7 +274,12 @@ func TestApplyInstancesChangeDropsActiveInstance(t *testing.T) {
 	cfg2 := &config.Config{
 		Active: "office",
 		Instances: []config.Instance{
-			{Name: "office", URL: "http://127.0.0.1:1", Password: "pw2", VerifyTLS: &verify},
+			{
+				Name:      "office",
+				URL:       "http://127.0.0.1:1",
+				Password:  "pw2",
+				VerifyTLS: &verify,
+			},
 		},
 	}
 
@@ -255,7 +289,10 @@ func TestApplyInstancesChangeDropsActiveInstance(t *testing.T) {
 		t.Fatal("config should be swapped in even when active is dropped")
 	}
 	if m.ctx.InstanceName != "office" {
-		t.Fatalf("surviving instance should be re-activated, got %q", m.ctx.InstanceName)
+		t.Fatalf(
+			"surviving instance should be re-activated, got %q",
+			m.ctx.InstanceName,
+		)
 	}
 	if m.err != "" {
 		t.Fatalf("re-activation should not synchronously error, got %q", m.err)
@@ -265,7 +302,8 @@ func TestApplyInstancesChangeDropsActiveInstance(t *testing.T) {
 func TestSwitchInstanceProceedsWithoutBlocking(t *testing.T) {
 	m := sized(t, newTestModel(t), 120, 36)
 	// Even pointed at a closed port, switching must not block on auth: it
-	// activates the instance and returns a fetch command; failures surface later.
+	// activates the instance and returns a fetch command; failures surface
+	// later.
 	m.cfg.Instances[1].URL = "http://127.0.0.1:1"
 
 	cmd := m.switchInstance("office")
@@ -277,14 +315,18 @@ func TestSwitchInstanceProceedsWithoutBlocking(t *testing.T) {
 		t.Fatalf("switch should not synchronously error, got %q", m.err)
 	}
 	if m.ctx.InstanceName != "office" {
-		t.Fatalf("instance name should advance to office, got %q", m.ctx.InstanceName)
+		t.Fatalf(
+			"instance name should advance to office, got %q",
+			m.ctx.InstanceName,
+		)
 	}
 }
 
 func TestSwitchInstanceStructuralErrorSetsBanner(t *testing.T) {
 	m := sized(t, newTestModel(t), 120, 36)
 	// Give office an unset password_env: clientFor can't resolve it, which is a
-	// structural config error that must still surface as a banner (not a crash),
+	// structural config error that must still surface as a banner (not a
+	// crash),
 	// leaving the active instance unchanged.
 	m.cfg.Instances[1].Password = ""
 	m.cfg.Instances[1].PasswordEnv = "TIHOLE_TEST_UNSET_PW"
@@ -298,7 +340,10 @@ func TestSwitchInstanceStructuralErrorSetsBanner(t *testing.T) {
 		t.Fatal("structural config error should surface a banner")
 	}
 	if m.ctx.InstanceName != "home" {
-		t.Fatalf("active instance should remain home, got %q", m.ctx.InstanceName)
+		t.Fatalf(
+			"active instance should remain home, got %q",
+			m.ctx.InstanceName,
+		)
 	}
 }
 
@@ -344,7 +389,12 @@ func TestPaletteCommandRunsEmitExpectedMessages(t *testing.T) {
 		}
 	}
 	if navRun == nil || themeRun == nil || instRun == nil {
-		t.Fatalf("missing palette commands: nav=%v theme=%v inst=%v", navRun != nil, themeRun != nil, instRun != nil)
+		t.Fatalf(
+			"missing palette commands: nav=%v theme=%v inst=%v",
+			navRun != nil,
+			themeRun != nil,
+			instRun != nil,
+		)
 	}
 
 	if _, ok := navRun().(core.NavigateMsg); !ok {
@@ -406,7 +456,10 @@ func TestSwitchInstanceKeyIsHandled(t *testing.T) {
 		t.Fatal("switch-instance key should be handled")
 	}
 	if m.ctx.InstanceName != "office" {
-		t.Fatalf("switch should activate the next instance, got %q", m.ctx.InstanceName)
+		t.Fatalf(
+			"switch should activate the next instance, got %q",
+			m.ctx.InstanceName,
+		)
 	}
 	if m.err != "" {
 		t.Fatalf("switch should not synchronously error, got %q", m.err)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -22,8 +22,18 @@ func newTestModel(t *testing.T) *AppModel {
 		Active: "home",
 		Theme:  "deep-night",
 		Instances: []config.Instance{
-			{Name: "home", URL: "http://192.168.1.2", Password: "pw", VerifyTLS: &verify},
-			{Name: "office", URL: "http://10.0.0.2", Password: "pw2", VerifyTLS: &verify},
+			{
+				Name:      "home",
+				URL:       "http://192.168.1.2",
+				Password:  "pw",
+				VerifyTLS: &verify,
+			},
+			{
+				Name:      "office",
+				URL:       "http://10.0.0.2",
+				Password:  "pw2",
+				VerifyTLS: &verify,
+			},
 		},
 	}
 	api := pihole.New("http://192.168.1.2", "pw")
@@ -97,7 +107,8 @@ func TestDashboardIsNotInteractiveSoRailKeepsFocus(t *testing.T) {
 	// Arrange: fresh model starts on the read-only dashboard, rail focused.
 	m := sized(t, newTestModel(t), 100, 30)
 
-	// Act / Assert: enter, tab, and → all refuse to descend into the dashboard —
+	// Act / Assert: enter, tab, and → all refuse to descend into the
+	// dashboard —
 	// there is nothing actionable there, so focus stays on the rail.
 	for _, k := range []struct {
 		text string
@@ -106,7 +117,11 @@ func TestDashboardIsNotInteractiveSoRailKeepsFocus(t *testing.T) {
 		updated, _ := m.Update(keyPress(k.text, k.code))
 		m = updated.(*AppModel)
 		if m.focus != focusNav {
-			t.Fatalf("%q should leave focus on the rail for the dashboard, got %v", k.text, m.focus)
+			t.Fatalf(
+				"%q should leave focus on the rail for the dashboard, got %v",
+				k.text,
+				m.focus,
+			)
 		}
 	}
 }
@@ -132,7 +147,8 @@ func TestDigitKeyJumpsToPage(t *testing.T) {
 	// Arrange
 	m := sized(t, newTestModel(t), 100, 30)
 
-	// Act: "3" -> third page (Query Log), staying on the rail for fast browsing.
+	// Act: "3" -> third page (Query Log), staying on the rail for fast
+	// browsing.
 	updated, _ := m.Update(keyPress("3", '3'))
 	m = updated.(*AppModel)
 
@@ -187,8 +203,11 @@ func TestBlockingResultUpdatesState(t *testing.T) {
 	// Arrange
 	m := sized(t, newTestModel(t), 100, 30)
 
-	// Act: a fresh status arrives (drives what the global "d" toggle will flip).
-	updated, _ := m.Update(blockingResultMsg{status: pihole.BlockingStatus{Blocking: true}})
+	// Act: a fresh status arrives (drives what the global "d" toggle will
+	// flip).
+	updated, _ := m.Update(
+		blockingResultMsg{status: pihole.BlockingStatus{Blocking: true}},
+	)
 	m = updated.(*AppModel)
 
 	// Assert: the app tracks the known+enabled state for the quick-toggle.
@@ -319,7 +338,13 @@ func TestPaletteCommandsIncludeNavigationAndThemes(t *testing.T) {
 		}
 	}
 	if !hasNav || !hasBlock || !hasTheme || !hasInstance {
-		t.Fatalf("missing command kinds: nav=%v block=%v theme=%v instance=%v", hasNav, hasBlock, hasTheme, hasInstance)
+		t.Fatalf(
+			"missing command kinds: nav=%v block=%v theme=%v instance=%v",
+			hasNav,
+			hasBlock,
+			hasTheme,
+			hasInstance,
+		)
 	}
 }
 
@@ -336,7 +361,8 @@ func TestHelpKeyOpensAndRendersOverlay(t *testing.T) {
 		t.Fatal("expected showHelp true after '?'")
 	}
 	out := m.View().Content
-	if !strings.Contains(out, "Keyboard shortcuts") || !strings.Contains(out, "Global") {
+	if !strings.Contains(out, "Keyboard shortcuts") ||
+		!strings.Contains(out, "Global") {
 		t.Error("view should render the help overlay")
 	}
 }

--- a/internal/tui/boot_test.go
+++ b/internal/tui/boot_test.go
@@ -20,7 +20,12 @@ func bootingModel(t *testing.T) *AppModel {
 		Active: "home",
 		Theme:  "deep-night",
 		Instances: []config.Instance{
-			{Name: "home", URL: "http://192.168.1.2", Password: "pw", VerifyTLS: &verify},
+			{
+				Name:      "home",
+				URL:       "http://192.168.1.2",
+				Password:  "pw",
+				VerifyTLS: &verify,
+			},
 		},
 	}
 	api := pihole.New("http://192.168.1.2", "pw")
@@ -39,7 +44,10 @@ func TestBootShowsSplashBeforeDashboard(t *testing.T) {
 		t.Errorf("expected boot splash, got:\n%s", out)
 	}
 	if strings.Contains(out, "Dashboard") {
-		t.Errorf("dashboard chrome should be hidden behind the splash:\n%s", out)
+		t.Errorf(
+			"dashboard chrome should be hidden behind the splash:\n%s",
+			out,
+		)
 	}
 }
 

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -30,10 +30,15 @@ func clientFor(cfg *config.Config, name string) (*pihole.Client, error) {
 }
 
 // fallbackClient builds a best-effort, unauthenticated client so the TUI can
-// still start (in the config editor) when clientFor fails. It never returns nil.
+// still start (in the config editor) when clientFor fails. It never returns
+// nil.
 func fallbackClient(cfg *config.Config, name string) *pihole.Client {
 	if inst := findInstance(cfg, name); inst != nil {
-		return pihole.New(inst.URL, "", pihole.WithInsecureTLS(!inst.VerifyTLSValue()))
+		return pihole.New(
+			inst.URL,
+			"",
+			pihole.WithInsecureTLS(!inst.VerifyTLSValue()),
+		)
 	}
 	return pihole.New("", "")
 }

--- a/internal/tui/client_test.go
+++ b/internal/tui/client_test.go
@@ -12,8 +12,17 @@ func testConfig() *config.Config {
 	return &config.Config{
 		Active: "home",
 		Instances: []config.Instance{
-			{Name: "home", URL: "http://192.168.1.2", Password: "pw", VerifyTLS: &verify},
-			{Name: "envonly", URL: "http://10.0.0.2", PasswordEnv: "TIHOLE_TEST_UNSET_PW"},
+			{
+				Name:      "home",
+				URL:       "http://192.168.1.2",
+				Password:  "pw",
+				VerifyTLS: &verify,
+			},
+			{
+				Name:        "envonly",
+				URL:         "http://10.0.0.2",
+				PasswordEnv: "TIHOLE_TEST_UNSET_PW",
+			},
 		},
 	}
 }
@@ -22,7 +31,8 @@ func TestClientForBuildsWithoutAuthenticating(t *testing.T) {
 	// Arrange
 	cfg := testConfig()
 
-	// Act: clientFor must NOT perform network auth, so it returns quickly with a
+	// Act: clientFor must NOT perform network auth, so it returns quickly with
+	// a
 	// usable client even though nothing is listening.
 	c, err := clientFor(cfg, "home")
 

--- a/internal/tui/components/confirm.go
+++ b/internal/tui/components/confirm.go
@@ -23,7 +23,12 @@ type ConfirmDialog struct {
 
 // Show returns a copy of the dialog activated with the given title/message.
 func (d ConfirmDialog) Show(title, message string, danger bool) ConfirmDialog {
-	return ConfirmDialog{Active: true, Title: title, Message: message, Danger: danger}
+	return ConfirmDialog{
+		Active:  true,
+		Title:   title,
+		Message: message,
+		Danger:  danger,
+	}
 }
 
 // Hide returns a copy with Active cleared.

--- a/internal/tui/components/confirm_test.go
+++ b/internal/tui/components/confirm_test.go
@@ -18,7 +18,8 @@ func TestConfirmShowActivatesWithText(t *testing.T) {
 	if !d.Active {
 		t.Fatal("expected dialog to be active after Show")
 	}
-	if d.Title != "Delete domain?" || d.Message != "ads.example.com" || !d.Danger {
+	if d.Title != "Delete domain?" || d.Message != "ads.example.com" ||
+		!d.Danger {
 		t.Fatalf("unexpected dialog state: %+v", d)
 	}
 }

--- a/internal/tui/components/gradient.go
+++ b/internal/tui/components/gradient.go
@@ -10,40 +10,82 @@ import (
 	"github.com/zackkitzmiller/tihole/internal/theme"
 )
 
-// gradientText renders s with a smooth per-rune color sweep from `from` to `to`.
+// gradientText renders s with a smooth per-rune color sweep from `from` to
+// `to`.
 // It is the small bit of whimsy the wordmark and gauges lean on; a single-rune
 // (or empty) string simply takes the start color.
 func gradientText(s string, from, to color.Color) string {
+	return gradientRamp(s, []color.Color{from, to})
+}
+
+// gradientRamp renders s with a per-rune sweep across an arbitrary number of
+// color stops. Two stops reduce to a plain linear blend; more stops chain
+// piecewise so a brand ramp (pink→magenta→purple→acid→cyan) reads smoothly
+// across a wordmark. An empty string, or an empty stop set, is returned as-is.
+func gradientRamp(s string, stops []color.Color) string {
 	runes := []rune(s)
 	n := len(runes)
-	if n == 0 {
+	if n == 0 || len(stops) == 0 {
 		return s
 	}
-	fr, fg, fb := rgb(from)
-	tr, tg, tb := rgb(to)
+	if len(stops) == 1 {
+		return lipgloss.NewStyle().Foreground(stops[0]).Bold(true).Render(s)
+	}
 
 	var b strings.Builder
 	for i, r := range runes {
-		t := 0.0
-		if n > 1 {
-			t = float64(i) / float64(n-1)
-		}
-		col := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
-			lerp(fr, tr, t), lerp(fg, tg, t), lerp(fb, tb, t)))
-		b.WriteString(lipgloss.NewStyle().Foreground(col).Bold(true).Render(string(r)))
+		col := rampColorAt(stops, positionOf(i, n))
+		b.WriteString(
+			lipgloss.NewStyle().Foreground(col).Bold(true).Render(string(r)),
+		)
 	}
 	return b.String()
 }
 
-// gradientWordmark is the sidebar brand: a gradient "tihole" that runs from the
-// accent to the allow token when the rail is focused, and quiets to a subtle
+// rampColorAt samples a piecewise-linear gradient defined by stops at position
+// t in [0,1]: t maps across len(stops)-1 equal segments, blending the two stops
+// that bracket it. Out-of-range t clamps to the end stops.
+func rampColorAt(stops []color.Color, t float64) color.Color {
+	if t <= 0 {
+		return stops[0]
+	}
+	if t >= 1 {
+		return stops[len(stops)-1]
+	}
+	segs := len(stops) - 1
+	x := t * float64(segs)
+	i := int(x)
+	if i >= segs {
+		i = segs - 1
+	}
+	local := x - float64(i)
+	ar, ag, ab := rgb(stops[i])
+	br, bg, bb := rgb(stops[i+1])
+	return lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
+		lerp(ar, br, local), lerp(ag, bg, local), lerp(ab, bb, local)))
+}
+
+// positionOf is the [0,1] position of index i within n items; a single item
+// sits at the start.
+func positionOf(i, n int) float64 {
+	if n <= 1 {
+		return 0
+	}
+	return float64(i) / float64(n-1)
+}
+
+// gradientWordmark is the sidebar brand: a gradient "tihole" that sweeps the
+// theme's signature ramp when the rail is focused, and quiets to a subtle
 // monochrome when the panel owns input.
 func gradientWordmark(th *theme.Theme, focused bool) string {
-	frame := lipgloss.NewStyle().Padding(0, 2).MarginBottom(1)
+	frame := lipgloss.NewStyle().
+		Padding(0, 2).
+		MarginBottom(1).
+		Background(th.Panel)
 	if !focused {
 		return frame.Foreground(th.Subtle).Bold(true).Render("● tihole")
 	}
-	return frame.Render(gradientText("● tihole", th.Accent, th.Allow))
+	return frame.Render(gradientRamp("● tihole", th.GradientStops()))
 }
 
 // rgb unpacks a color.Color into 8-bit channels. lipgloss colors expose 16-bit

--- a/internal/tui/components/helpsheet.go
+++ b/internal/tui/components/helpsheet.go
@@ -62,7 +62,11 @@ func (h HelpSheet) Render(th *theme.Theme, width, height int) string {
 }
 
 // renderSection renders a section heading followed by aligned key/desc rows.
-func (h HelpSheet) renderSection(th *theme.Theme, sec HelpSection, width int) string {
+func (h HelpSheet) renderSection(
+	th *theme.Theme,
+	sec HelpSection,
+	width int,
+) string {
 	heading := lipgloss.NewStyle().
 		Foreground(th.Text).
 		Bold(true).

--- a/internal/tui/components/palette.go
+++ b/internal/tui/components/palette.go
@@ -162,10 +162,17 @@ func (p Palette) Render(th *theme.Theme, width, height int) string {
 
 	start, end := windowBounds(p.cursor, len(p.filtered), paletteMaxRows)
 	for i := start; i < end; i++ {
-		rows = append(rows, p.renderRow(th, p.filtered[i], i == p.cursor, boxWidth-2))
+		rows = append(
+			rows,
+			p.renderRow(th, p.filtered[i], i == p.cursor, boxWidth-2),
+		)
 	}
 
-	rows = append(rows, "", th.SubtleStyle().Render("↑↓ move · enter run · esc close"))
+	rows = append(
+		rows,
+		"",
+		th.SubtleStyle().Render("↑↓ move · enter run · esc close"),
+	)
 
 	box := lipgloss.NewStyle().
 		Background(th.Panel).
@@ -179,7 +186,12 @@ func (p Palette) Render(th *theme.Theme, width, height int) string {
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box)
 }
 
-func (p Palette) renderRow(th *theme.Theme, c Command, selected bool, width int) string {
+func (p Palette) renderRow(
+	th *theme.Theme,
+	c Command,
+	selected bool,
+	width int,
+) string {
 	title := c.Title
 	desc := c.Desc
 	if selected {
@@ -191,7 +203,10 @@ func (p Palette) renderRow(th *theme.Theme, c Command, selected bool, width int)
 			Padding(0, 1).
 			Render(title)
 		if desc != "" {
-			row += "\n" + lipgloss.NewStyle().Foreground(th.Subtle).Padding(0, 1).Render(desc)
+			row += "\n" + lipgloss.NewStyle().
+				Foreground(th.Subtle).
+				Padding(0, 1).
+				Render(desc)
 		}
 		return row
 	}

--- a/internal/tui/components/palette_test.go
+++ b/internal/tui/components/palette_test.go
@@ -57,7 +57,9 @@ func TestPaletteFilterMultiTerm(t *testing.T) {
 func TestPaletteEnterRunsSelectedCommand(t *testing.T) {
 	// Arrange
 	ran := false
-	cmds := []Command{{Title: "Do it", Run: func() tea.Msg { ran = true; return nil }}}
+	cmds := []Command{
+		{Title: "Do it", Run: func() tea.Msg { ran = true; return nil }},
+	}
 	p := NewPalette()
 	p, _ = p.Open(cmds)
 
@@ -233,7 +235,10 @@ func TestPaletteRenderScrollsWithManyCommands(t *testing.T) {
 	// Arrange: more commands than paletteMaxRows forces windowBounds scrolling.
 	var cmds []Command
 	for i := 0; i < 20; i++ {
-		cmds = append(cmds, Command{Title: "Command " + string(rune('A'+i)), Desc: "desc"})
+		cmds = append(
+			cmds,
+			Command{Title: "Command " + string(rune('A'+i)), Desc: "desc"},
+		)
 	}
 	p := NewPalette()
 	p, _ = p.Open(cmds)
@@ -246,7 +251,10 @@ func TestPaletteRenderScrollsWithManyCommands(t *testing.T) {
 
 	// Assert: a later command is visible; the first is scrolled out of view.
 	if !strings.Contains(out, "Command P") {
-		t.Fatalf("expected scrolled window to show a later command, got %q", out)
+		t.Fatalf(
+			"expected scrolled window to show a later command, got %q",
+			out,
+		)
 	}
 }
 

--- a/internal/tui/components/sectiontabs.go
+++ b/internal/tui/components/sectiontabs.go
@@ -20,7 +20,8 @@ type SectionTabs struct {
 	Labels []string
 	// Active is the index into Labels of the highlighted chip.
 	Active int
-	// Right is an optional right-aligned summary (counts, totals). Empty hides it.
+	// Right is an optional right-aligned summary (counts, totals). Empty hides
+	// it.
 	Right string
 	// Width is the available line width, used to right-align Right.
 	Width int
@@ -29,38 +30,86 @@ type SectionTabs struct {
 // Render returns the single-line tab bar. Callers typically stack an error
 // banner or spacer beneath it.
 func (s SectionTabs) Render(th *theme.Theme) string {
-	active := lipgloss.NewStyle().Foreground(th.Surface).Background(th.Accent).Bold(true)
+	// A segmented control: the active chip is a filled brand pill, the rest sit
+	// on
+	// the raised panel so the whole bar reads as one glossy switch rather than
+	// loose words. A hairline between chips keeps the segments legible.
+	//
+	// Every filler — the inter-chip spaces, the title gutter, the gap before
+	// the right summary — is rendered *with* a background. A plain space sits
+	// after a styled run's reset and paints in the terminal's own background,
+	// so it would
+	// bleed through as a gap; carrying a background keeps the band continuous.
+	surface := lipgloss.NewStyle().Background(th.Surface)
+	panelBG := lipgloss.NewStyle().Background(th.Panel)
+	active := lipgloss.NewStyle().
+		Foreground(th.Surface).
+		Background(th.Accent).
+		Bold(true)
+	inactive := lipgloss.NewStyle().Foreground(th.Subtle).Background(th.Panel)
+	sep := lipgloss.NewStyle().
+		Foreground(th.Border).
+		Background(th.Panel).
+		Render("│")
 
-	chips := make([]string, len(s.Labels))
+	chips := make([]string, 0, len(s.Labels)*2)
 	for i, l := range s.Labels {
+		if i > 0 && i != s.Active && (i-1) != s.Active {
+			chips = append(chips, sep)
+		} else if i > 0 {
+			chips = append(chips, panelBG.Render(" "))
+		}
 		label := " " + l + " "
 		if i == s.Active {
-			chips[i] = active.Render(label)
+			chips = append(chips, active.Render(label))
 		} else {
-			chips[i] = th.SubtleStyle().Render(label)
+			chips = append(chips, inactive.Render(label))
 		}
 	}
 	bar := lipgloss.JoinHorizontal(lipgloss.Center, chips...)
 
 	left := bar
 	if s.Title != "" {
-		left = lipgloss.JoinHorizontal(lipgloss.Center, th.AccentStyle().Bold(true).Render(s.Title), "  ", bar)
+		title := lipgloss.NewStyle().
+			Foreground(th.Accent).
+			Background(th.Surface).
+			Bold(true).
+			Render(s.Title)
+		left = lipgloss.JoinHorizontal(
+			lipgloss.Center,
+			title,
+			surface.Render("  "),
+			bar,
+		)
 	}
 
 	line := left
 	if s.Right != "" {
+		right := lipgloss.NewStyle().
+			Foreground(th.Subtle).
+			Background(th.Surface).
+			Render(s.Right)
 		gap := s.Width - lipgloss.Width(left) - lipgloss.Width(s.Right)
 		if gap < 1 {
 			gap = 1
 		}
-		line = left + strings.Repeat(" ", gap) + s.Right
+		line = lipgloss.JoinHorizontal(
+			lipgloss.Center,
+			left,
+			surface.Render(strings.Repeat(" ", gap)),
+			right,
+		)
 	}
 
-	// Clamp to the available width so an oversized bar (many chips on a narrow
-	// terminal) is truncated rather than wrapping onto a second line, which would
-	// throw off every caller's header-height math.
+	// Clamp to width with MaxWidth only: an oversized bar (many chips on a
+	// narrow terminal) is truncated rather than wrapping onto a second line,
+	// which would
+	// throw off every caller's header-height math. MaxWidth (not Width) avoids
+	// soft-wrapping. Every segment already carries its own background, and the
+	// caller paints the surrounding surface, so no trailing fill is needed
+	// here.
 	if s.Width > 0 {
-		line = lipgloss.NewStyle().MaxWidth(s.Width).Render(line)
+		return lipgloss.NewStyle().MaxWidth(s.Width).Render(line)
 	}
 	return line
 }

--- a/internal/tui/components/sidebar.go
+++ b/internal/tui/components/sidebar.go
@@ -44,7 +44,8 @@ func (s Sidebar) Render(th *theme.Theme) string {
 	var rows []string
 	rows = append(rows, brand)
 
-	// The selection glows on the accent when the rail is focused; when the panel
+	// The selection glows on the accent when the rail is focused; when the
+	// panel
 	// owns input the rail steps back to a muted, bordered pill so it's clear
 	// where the keyboard is going.
 	selFg, selBg := th.Surface, th.Accent
@@ -52,7 +53,13 @@ func (s Sidebar) Render(th *theme.Theme) string {
 		selFg, selBg = th.Text, th.Border
 	}
 
-	itemBase := lipgloss.NewStyle().Width(width-2).Padding(0, 1)
+	// itemBase carries the Panel background so the Width padding after each
+	// (fg-only) label paints the rail surface instead of leaking the terminal
+	// background through the trailing cells.
+	itemBase := lipgloss.NewStyle().
+		Width(width-2).
+		Padding(0, 1).
+		Background(th.Panel)
 	for i, item := range s.Items {
 		marker := "  "
 		if i == s.Selected {

--- a/internal/tui/components/sidebar_test.go
+++ b/internal/tui/components/sidebar_test.go
@@ -31,7 +31,8 @@ func TestSidebarRenderShowsAllItems(t *testing.T) {
 }
 
 func TestSidebarRenderMarksSelectedItem(t *testing.T) {
-	// Arrange: selecting a middle item should style it differently than the rest.
+	// Arrange: selecting a middle item should style it differently than the
+	// rest.
 	selected := Sidebar{Items: sampleSidebarItems(), Selected: 1, Height: 20}
 	other := Sidebar{Items: sampleSidebarItems(), Selected: 0, Height: 20}
 
@@ -49,7 +50,11 @@ func TestSidebarRenderMarksSelectedItem(t *testing.T) {
 func TestSidebarRenderUsesDefaultWidthWhenZero(t *testing.T) {
 	// Arrange: Width 0 should fall back to SidebarWidth.
 	zero := Sidebar{Items: sampleSidebarItems(), Height: 10}
-	explicit := Sidebar{Items: sampleSidebarItems(), Width: SidebarWidth, Height: 10}
+	explicit := Sidebar{
+		Items:  sampleSidebarItems(),
+		Width:  SidebarWidth,
+		Height: 10,
+	}
 
 	// Act / Assert
 	if zero.Render(theme.DeepNight()) != explicit.Render(theme.DeepNight()) {

--- a/internal/tui/components/splash.go
+++ b/internal/tui/components/splash.go
@@ -1,7 +1,6 @@
 package components
 
 import (
-	"fmt"
 	"image/color"
 	"strings"
 
@@ -33,38 +32,60 @@ type Splash struct {
 
 // Render composes the centered boot screen on the theme surface.
 func (s Splash) Render(th *theme.Theme) string {
-	banner := verticalGradient(splashArt, th.Accent, th.Allow)
+	banner := verticalGradientRamp(splashArt, th.GradientStops())
 
 	tagline := lipgloss.NewStyle().Foreground(th.Subtle).
 		Render("PiHole v6 · terminal control")
 
 	parts := []string{banner, "", tagline}
 	if s.Instance != "" {
-		parts = append(parts, lipgloss.NewStyle().Foreground(th.Accent).Bold(true).
-			Render("▸ "+s.Instance))
+		parts = append(
+			parts,
+			lipgloss.NewStyle().Foreground(th.Accent).Bold(true).
+				Render("▸ "+s.Instance),
+		)
 	}
 	if s.Status != "" {
-		parts = append(parts, "", lipgloss.NewStyle().Foreground(th.Subtle).Render(s.Status))
+		parts = append(
+			parts,
+			"",
+			lipgloss.NewStyle().Foreground(th.Subtle).Render(s.Status),
+		)
 	}
 
-	// A compact key legend so the essential shortcuts are learned on the way in,
+	// A compact key legend so the essential shortcuts are learned on the way
+	// in,
 	// not hunted for later.
 	legend := lipgloss.NewStyle().Foreground(th.Subtle).Render(
 		"ctrl+k palette · ? help · ⌃T theme · i splash")
 	parts = append(parts, "", legend)
 
 	block := lipgloss.JoinVertical(lipgloss.Center, parts...)
-	centered := lipgloss.Place(s.Width, s.Height, lipgloss.Center, lipgloss.Center, block)
+	centered := lipgloss.Place(
+		s.Width,
+		s.Height,
+		lipgloss.Center,
+		lipgloss.Center,
+		block,
+	)
 	return th.SurfaceStyle().Width(s.Width).Height(s.Height).Render(centered)
 }
 
 // verticalGradient colors each line of s by its row position, blending from
 // `from` at the top to `to` at the bottom. A single line takes `from`.
 func verticalGradient(s string, from, to color.Color) string {
+	return verticalGradientRamp(s, []color.Color{from, to})
+}
+
+// verticalGradientRamp colors each line of s by its row position, sweeping the
+// full stop set from top to bottom so the boot banner carries the signature
+// brand ramp. A single line takes the first stop.
+func verticalGradientRamp(s string, stops []color.Color) string {
 	lines := strings.Split(s, "\n")
 	n := len(lines)
-	fr, fg, fb := rgb(from)
-	tr, tg, tb := rgb(to)
+	if len(stops) == 0 {
+		return s
+	}
 
 	// Right-pad every line to a common width so ragged glyph rows (e.g. the "E"
 	// in an ANSI-shadow font) keep their left edges aligned when centered.
@@ -77,15 +98,10 @@ func verticalGradient(s string, from, to color.Color) string {
 
 	out := make([]string, n)
 	for i, line := range lines {
-		t := 0.0
-		if n > 1 {
-			t = float64(i) / float64(n-1)
-		}
 		if pad := maxW - len([]rune(line)); pad > 0 {
 			line += strings.Repeat(" ", pad)
 		}
-		col := lipgloss.Color(fmt.Sprintf("#%02x%02x%02x",
-			lerp(fr, tr, t), lerp(fg, tg, t), lerp(fb, tb, t)))
+		col := rampColorAt(stops, positionOf(i, n))
 		out[i] = lipgloss.NewStyle().Foreground(col).Bold(true).Render(line)
 	}
 	return strings.Join(out, "\n")

--- a/internal/tui/components/splash_test.go
+++ b/internal/tui/components/splash_test.go
@@ -46,14 +46,25 @@ func TestVerticalGradientAlignsRaggedRows(t *testing.T) {
 	art := "████\n██"
 
 	// Act
-	out := ansi.Strip(verticalGradient(art, theme.DeepNight().Accent, theme.DeepNight().Allow))
+	out := ansi.Strip(
+		verticalGradient(
+			art,
+			theme.DeepNight().Accent,
+			theme.DeepNight().Allow,
+		),
+	)
 
-	// Assert: the shorter row is right-padded to match, so both are equal width.
+	// Assert: the shorter row is right-padded to match, so both are equal
+	// width.
 	lines := strings.Split(out, "\n")
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
 	if len([]rune(lines[0])) != len([]rune(lines[1])) {
-		t.Errorf("rows not aligned: %d vs %d", len([]rune(lines[0])), len([]rune(lines[1])))
+		t.Errorf(
+			"rows not aligned: %d vs %d",
+			len([]rune(lines[0])),
+			len([]rune(lines[1])),
+		)
 	}
 }

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -1,18 +1,70 @@
 package components
 
 import (
+	"fmt"
+
 	"charm.land/lipgloss/v2"
 
 	"github.com/zackkitzmiller/tihole/internal/theme"
 )
 
-// StatusBar renders the top chrome: the active instance, the current screen
-// title, and the active theme (with its cycle-key hint) on the right. Blocking
-// is its own pane now. Pure view helper driven by the root model.
+// StatusBar renders the top chrome: the active instance, a persistent
+// blocking-status pill, the current screen title, and the active theme (with
+// its cycle-key hint) on the right. The blocking pill rides the top bar on
+// EVERY screen so "protection is off" can never hide on another tab. Pure view
+// helper driven by the root model.
 type StatusBar struct {
 	Instance   string
 	ScreenName string
 	Width      int
+	// Blocking is the current global blocking status, surfaced as an always-on
+	// pill. Its zero value (Known == false) renders a muted "blocking …" while
+	// the first fetch is in flight.
+	Blocking BlockState
+}
+
+// blockingPill renders the always-on blocking indicator: a calm green badge
+// when protection is on, and an alarming filled-red badge (with the
+// temporary-disable countdown, when running) when it is off — so a disabled
+// state stands out from anywhere in the app.
+func (b StatusBar) blockingPill(th *theme.Theme) string {
+	base := lipgloss.NewStyle().Bold(true).Padding(0, 1)
+
+	if !b.Blocking.Known {
+		return base.
+			Foreground(th.Subtle).
+			Background(th.Panel).
+			Render("◌ blocking …")
+	}
+	if b.Blocking.Enabled {
+		return base.
+			Foreground(th.Surface).
+			Background(th.Allow).
+			Render("● BLOCKING ON")
+	}
+
+	label := "⚠ BLOCKING OFF"
+	if b.Blocking.CountdownSecs > 0 {
+		label = fmt.Sprintf("⚠ OFF %s", fmtCountdown(b.Blocking.CountdownSecs))
+	}
+	return base.
+		Foreground(th.Surface).
+		Background(th.Block).
+		Render(label)
+}
+
+// fmtCountdown renders remaining seconds as m:ss (or h:mm:ss past an hour).
+func fmtCountdown(secs int) string {
+	if secs < 0 {
+		secs = 0
+	}
+	h := secs / 3600
+	m := (secs % 3600) / 60
+	s := secs % 60
+	if h > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", h, m, s)
+	}
+	return fmt.Sprintf("%d:%02d", m, s)
 }
 
 // Render returns the styled top status bar for the given theme: a filled brand
@@ -54,7 +106,15 @@ func (b StatusBar) Render(th *theme.Theme) string {
 		Padding(0, 1).
 		Render("◐ " + th.Name + " ⌃T")
 
-	left := lipgloss.JoinHorizontal(lipgloss.Top, badge, instance, center)
+	pill := b.blockingPill(th)
+
+	left := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		badge,
+		pill,
+		instance,
+		center,
+	)
 
 	gap := b.Width - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 0 {

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -15,37 +15,59 @@ type StatusBar struct {
 	Width      int
 }
 
-// Render returns the styled top status bar for the given theme.
+// Render returns the styled top status bar for the given theme: a filled brand
+// badge, the active instance, the current screen, and a right-aligned theme
+// segment — all sitting as colored blocks on the panel, lipgloss-style.
 func (b StatusBar) Render(th *theme.Theme) string {
-	left := lipgloss.NewStyle().
-		Foreground(th.Accent).
+	// A filled brand badge anchors the bar the way lipgloss's "STATUS" pill
+	// does.
+	badge := lipgloss.NewStyle().
+		Foreground(th.Surface).
+		Background(th.Accent).
 		Bold(true).
 		Padding(0, 1).
-		Render("⬢ " + orDash(b.Instance))
+		Render("⬢ TIHOLE")
+
+	// Interior segments carry the panel background explicitly. A fill-only
+	// style
+	// (fg without bg) resets to the terminal's own background after its run, so
+	// the panel band would otherwise bleed between the badge and the segments.
+	instance := lipgloss.NewStyle().
+		Foreground(th.Accent).
+		Background(th.Panel).
+		Bold(true).
+		Padding(0, 1).
+		Render(orDash(b.Instance))
 
 	center := lipgloss.NewStyle().
 		Foreground(th.Text).
+		Background(th.Panel).
+		Bold(true).
 		Padding(0, 1).
 		Render(b.ScreenName)
 
-	// Advertise the active theme and how to change it, so appearance stops being
-	// a palette-only secret.
+	// Advertise the active theme and how to change it as a filled segment, so
+	// appearance stops being a palette-only secret.
 	right := lipgloss.NewStyle().
-		Foreground(th.Subtle).
+		Foreground(th.Text).
+		Background(th.Border).
 		Padding(0, 1).
-		Render("◐ " + th.Name + " (⌃T)")
+		Render("◐ " + th.Name + " ⌃T")
 
-	gap := b.Width - lipgloss.Width(left) - lipgloss.Width(center) - lipgloss.Width(right)
+	left := lipgloss.JoinHorizontal(lipgloss.Top, badge, instance, center)
+
+	gap := b.Width - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 0 {
 		gap = 0
 	}
-	spacer := lipgloss.NewStyle().Width(gap).Render("")
+	spacer := lipgloss.NewStyle().Background(th.Panel).Width(gap).Render("")
 
-	row := lipgloss.JoinHorizontal(lipgloss.Top, left, center, spacer, right)
+	row := lipgloss.JoinHorizontal(lipgloss.Top, left, spacer, right)
 
 	return lipgloss.NewStyle().
 		Width(b.Width).
 		Background(th.Panel).
+		MaxWidth(b.Width).
 		Render(row)
 }
 

--- a/internal/tui/components/statusbar_test.go
+++ b/internal/tui/components/statusbar_test.go
@@ -42,6 +42,90 @@ func TestStatusBarRenderNarrowWidthDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestStatusBarShowsBlockingOnWhenEnabled(t *testing.T) {
+	// Arrange
+	b := StatusBar{
+		Instance:   "home-pi",
+		ScreenName: "Query Log",
+		Width:      120,
+		Blocking:   BlockState{Known: true, Enabled: true},
+	}
+
+	// Act
+	out := b.Render(theme.DeepNight())
+
+	// Assert
+	if !strings.Contains(out, "BLOCKING ON") {
+		t.Fatalf("expected on-state pill, got %q", out)
+	}
+}
+
+func TestStatusBarShowsBlockingOffWhenDisabled(t *testing.T) {
+	// Arrange
+	b := StatusBar{
+		Instance:   "home-pi",
+		ScreenName: "Query Log",
+		Width:      120,
+		Blocking:   BlockState{Known: true, Enabled: false},
+	}
+
+	// Act
+	out := b.Render(theme.DeepNight())
+
+	// Assert
+	if !strings.Contains(out, "BLOCKING OFF") {
+		t.Fatalf("expected off-state pill, got %q", out)
+	}
+}
+
+func TestStatusBarShowsCountdownOnTemporaryDisable(t *testing.T) {
+	// Arrange: 90s remaining renders as 1:30 alongside the OFF marker.
+	b := StatusBar{
+		Instance:   "home-pi",
+		ScreenName: "Query Log",
+		Width:      120,
+		Blocking:   BlockState{Known: true, Enabled: false, CountdownSecs: 90},
+	}
+
+	// Act
+	out := b.Render(theme.DeepNight())
+
+	// Assert
+	if !strings.Contains(out, "1:30") {
+		t.Fatalf("expected 1:30 countdown, got %q", out)
+	}
+}
+
+func TestStatusBarShowsPendingBlockingBeforeFirstFetch(t *testing.T) {
+	// Arrange: zero BlockState (Known == false) reads as a muted placeholder.
+	b := StatusBar{Instance: "home-pi", ScreenName: "Dashboard", Width: 120}
+
+	// Act
+	out := b.Render(theme.DeepNight())
+
+	// Assert
+	if !strings.Contains(out, "blocking …") {
+		t.Fatalf("expected pending placeholder, got %q", out)
+	}
+}
+
+func TestFmtCountdown(t *testing.T) {
+	// Arrange / Act / Assert
+	cases := map[int]string{
+		0:    "0:00",
+		9:    "0:09",
+		90:   "1:30",
+		600:  "10:00",
+		3661: "1:01:01",
+		-5:   "0:00",
+	}
+	for secs, want := range cases {
+		if got := fmtCountdown(secs); got != want {
+			t.Errorf("fmtCountdown(%d) = %q, want %q", secs, got, want)
+		}
+	}
+}
+
 func TestOrDash(t *testing.T) {
 	// Arrange / Act / Assert
 	if got := orDash(""); got != "—" {

--- a/internal/tui/components/table.go
+++ b/internal/tui/components/table.go
@@ -1,0 +1,32 @@
+package components
+
+import (
+	"charm.land/bubbles/v2/table"
+	"charm.land/lipgloss/v2"
+
+	"github.com/zackkitzmiller/tihole/internal/theme"
+)
+
+// TableStyles returns theme-aware styles for a bubbles table so every cell —
+// including the width padding the table adds to each column — carries an
+// explicit background. Without this the table uses library defaults that set no
+// background, and each padded cell leaks whatever is behind the terminal (a
+// solid colour, or a background image) straight through the list.
+func TableStyles(th *theme.Theme) table.Styles {
+	return table.Styles{
+		Header: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(th.Subtle).
+			Background(th.Panel).
+			Padding(0, 1),
+		Cell: lipgloss.NewStyle().
+			Foreground(th.Text).
+			Background(th.Surface).
+			Padding(0, 1),
+		Selected: lipgloss.NewStyle().
+			Bold(true).
+			Foreground(th.Surface).
+			Background(th.Accent).
+			Padding(0, 1),
+	}
+}

--- a/internal/tui/core/keys.go
+++ b/internal/tui/core/keys.go
@@ -85,14 +85,28 @@ func DefaultKeyMap() KeyMap {
 
 // ShortHelp implements help.KeyMap for the compact help bar.
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Palette, k.SwitchInst, k.ToggleBlock, k.CycleTheme, k.Help, k.Quit}
+	return []key.Binding{
+		k.Palette,
+		k.SwitchInst,
+		k.ToggleBlock,
+		k.CycleTheme,
+		k.Help,
+		k.Quit,
+	}
 }
 
 // FullHelp implements help.KeyMap for the expanded help view.
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right, k.Enter, k.Back},
-		{k.Palette, k.SwitchInst, k.ToggleBlock, k.CycleTheme, k.Refresh, k.Splash},
+		{
+			k.Palette,
+			k.SwitchInst,
+			k.ToggleBlock,
+			k.CycleTheme,
+			k.Refresh,
+			k.Splash,
+		},
 		{k.Help, k.Quit},
 	}
 }

--- a/internal/tui/core/nav.go
+++ b/internal/tui/core/nav.go
@@ -77,9 +77,11 @@ type Screen interface {
 	SetSize(width, height int)
 }
 
-// InputCapturer is an optional Screen capability. A screen returns true while it
+// InputCapturer is an optional Screen capability. A screen returns true while
+// it
 // has an editable text field focused, so the root delivers raw keys straight to
-// it instead of firing global single-key shortcuts (s, d, r, q, j/k, digits, …).
+// it instead of firing global single-key shortcuts (s, d, r, q, j/k, digits,
+// …).
 // Screens without text entry simply don't implement it and default to false.
 type InputCapturer interface {
 	CapturesInput() bool
@@ -87,7 +89,8 @@ type InputCapturer interface {
 
 // PanelInteractor is an optional Screen capability. A screen returns false from
 // Interactive() when it has no actionable content — a read-only dashboard, for
-// instance — so the nav rail refuses to descend into it: enter/tab/→ stay on the
+// instance — so the nav rail refuses to descend into it: enter/tab/→ stay
+// on the
 // rail. Screens that don't implement it default to interactive.
 type PanelInteractor interface {
 	Interactive() bool

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -43,7 +43,12 @@ func run(start core.PageID) error {
 	th, err := theme.Resolve(cfg.Theme)
 	if err != nil {
 		// Resolve already falls back to a built-in theme; keep going.
-		fmt.Fprintf(os.Stderr, "theme %q: %v (using fallback)\n", cfg.Theme, err)
+		fmt.Fprintf(
+			os.Stderr,
+			"theme %q: %v (using fallback)\n",
+			cfg.Theme,
+			err,
+		)
 	}
 
 	api, err := clientFor(cfg, cfg.Active)

--- a/internal/tui/screens/adlists/adlists.go
+++ b/internal/tui/screens/adlists/adlists.go
@@ -1,4 +1,5 @@
-// Package adlists implements the PiHole v6 adlists screen: block/allow list CRUD
+// Package adlists implements the PiHole v6 adlists screen: block/allow list
+// CRUD
 // over a bubbles table plus the streamed gravity update. It satisfies
 // core.Screen. All I/O happens inside tea.Cmd closures; Update never blocks.
 package adlists
@@ -115,7 +116,8 @@ func (m *Model) Init() tea.Cmd { return nil }
 func (m *Model) Title() string { return "Adlists" }
 
 // CapturesInput reports whether the add/edit form is focused, so the root
-// delivers raw keys instead of firing global shortcuts (see core.InputCapturer).
+// delivers raw keys instead of firing global shortcuts (see
+// core.InputCapturer).
 func (m *Model) CapturesInput() bool { return m.form.active }
 
 // Focus activates the screen: bump epoch and fetch both list types.
@@ -286,6 +288,7 @@ func (m *Model) syncRows() {
 		widths = computeColumnWidths(80)
 	}
 	idx := m.table.Cursor()
+	m.table.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.table.SetRows(styledRows(m.ctx.Theme, m.lists[m.visible], widths))
 	m.table.SetCursor(idx)
 }

--- a/internal/tui/screens/adlists/adlists_test.go
+++ b/internal/tui/screens/adlists/adlists_test.go
@@ -58,14 +58,18 @@ func TestListsMsgPopulatesRowsAndClearsLoading(t *testing.T) {
 	_, _ = m.Update(listsMsg{
 		epoch: 4,
 		block: []pihole.List{{Address: "a", Type: "block"}},
-		allow: []pihole.List{{Address: "b", Type: "allow"}, {Address: "c", Type: "allow"}},
+		allow: []pihole.List{
+			{Address: "b", Type: "allow"},
+			{Address: "c", Type: "allow"},
+		},
 	})
 
 	// Assert
 	if m.loading {
 		t.Fatalf("listsMsg should clear loading")
 	}
-	if len(m.lists[pihole.ListBlock]) != 1 || len(m.lists[pihole.ListAllow]) != 2 {
+	if len(m.lists[pihole.ListBlock]) != 1 ||
+		len(m.lists[pihole.ListAllow]) != 2 {
 		t.Fatalf("lists not populated: %v", m.lists)
 	}
 }
@@ -245,7 +249,15 @@ func TestFormEscCancels(t *testing.T) {
 func TestEditPrefillsForm(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://a", Comment: "c", Type: "block", Groups: []int{0, 2}, Enabled: true}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{
+			Address: "https://a",
+			Comment: "c",
+			Type:    "block",
+			Groups:  []int{0, 2},
+			Enabled: true,
+		},
+	}
 	m.syncRows()
 
 	// Act
@@ -256,10 +268,16 @@ func TestEditPrefillsForm(t *testing.T) {
 		t.Fatalf("e should open the edit form")
 	}
 	if m.form.address.Value() != "https://a" {
-		t.Fatalf("edit form should prefill address, got %q", m.form.address.Value())
+		t.Fatalf(
+			"edit form should prefill address, got %q",
+			m.form.address.Value(),
+		)
 	}
 	if m.form.groups.Value() != "0,2" {
-		t.Fatalf("edit form should prefill groups, got %q", m.form.groups.Value())
+		t.Fatalf(
+			"edit form should prefill groups, got %q",
+			m.form.groups.Value(),
+		)
 	}
 }
 
@@ -286,7 +304,9 @@ func TestFormTypeToggle(t *testing.T) {
 func TestDeleteOpensConfirm(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://gone", Type: "block"}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{Address: "https://gone", Type: "block"},
+	}
 	m.syncRows()
 
 	// Act
@@ -307,7 +327,9 @@ func TestDeleteOpensConfirm(t *testing.T) {
 func TestConfirmYesReturnsDeleteCmd(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://gone", Type: "block"}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{Address: "https://gone", Type: "block"},
+	}
 	m.syncRows()
 	_, _ = m.Update(keyPress("x"))
 
@@ -326,7 +348,9 @@ func TestConfirmYesReturnsDeleteCmd(t *testing.T) {
 func TestConfirmNoCancels(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://gone", Type: "block"}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{Address: "https://gone", Type: "block"},
+	}
 	m.syncRows()
 	_, _ = m.Update(keyPress("x"))
 
@@ -347,7 +371,9 @@ func TestConfirmNoCancels(t *testing.T) {
 func TestToggleEnabledReturnsCmd(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://a", Type: "block", Enabled: true}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{Address: "https://a", Type: "block", Enabled: true},
+	}
 	m.syncRows()
 
 	// Act
@@ -387,7 +413,9 @@ func TestConfirmGravityStartsStreaming(t *testing.T) {
 
 	// Assert
 	if !m.gravityOpen || !m.gravityRunning {
-		t.Fatalf("confirming gravity should open the log pane and start streaming")
+		t.Fatalf(
+			"confirming gravity should open the log pane and start streaming",
+		)
 	}
 	if m.gravityChan == nil {
 		t.Fatalf("gravity channel should be initialised")
@@ -405,7 +433,9 @@ func TestGravityLineAppendsToBuffer(t *testing.T) {
 	m.gravityRunning = true
 
 	// Act
-	_, cmd := m.Update(gravityLineMsg{epoch: 5, line: "[i] Building tree", ok: true})
+	_, cmd := m.Update(
+		gravityLineMsg{epoch: 5, line: "[i] Building tree", ok: true},
+	)
 
 	// Assert
 	if len(m.gravityLines) != 1 || m.gravityLines[0] != "[i] Building tree" {
@@ -531,7 +561,15 @@ func TestSetSizeSafeAtTinySizes(t *testing.T) {
 func TestViewRendersAtNormalSize(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://a", Type: "block", Enabled: true, Status: 1, Number: 5}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{
+			Address: "https://a",
+			Type:    "block",
+			Enabled: true,
+			Status:  1,
+			Number:  5,
+		},
+	}
 	m.syncRows()
 
 	// Act

--- a/internal/tui/screens/adlists/adlists_view_test.go
+++ b/internal/tui/screens/adlists/adlists_view_test.go
@@ -30,7 +30,8 @@ func TestHelpReturnsBindings(t *testing.T) {
 }
 
 func TestBlurClearsFocusAndCancelsInflight(t *testing.T) {
-	// Arrange: Focus arms a fetch cancel; a running gravity arms its own cancel.
+	// Arrange: Focus arms a fetch cancel; a running gravity arms its own
+	// cancel.
 	m := newTestModel()
 	m.Focus()
 	_, gravityCancel := context.WithCancel(context.Background())
@@ -78,7 +79,15 @@ func TestViewLoadedRendersHeaderChipAndFooter(t *testing.T) {
 	// Arrange
 	m := newTestModel()
 	m.Focus()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://a", Type: "block", Enabled: true, Status: 1, Number: 5}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{
+			Address: "https://a",
+			Type:    "block",
+			Enabled: true,
+			Status:  1,
+			Number:  5,
+		},
+	}
 	m.loading = false
 	m.syncRows()
 
@@ -155,7 +164,15 @@ func TestViewAddFormRendered(t *testing.T) {
 func TestViewEditFormRendersEnabledRow(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.form = m.form.openEdit(pihole.List{Address: "https://a", Comment: "c", Type: "block", Enabled: true, Groups: []int{0}})
+	m.form = m.form.openEdit(
+		pihole.List{
+			Address: "https://a",
+			Comment: "c",
+			Type:    "block",
+			Enabled: true,
+			Groups:  []int{0},
+		},
+	)
 	m.form.setWidth(m.w)
 
 	// Act
@@ -172,7 +189,9 @@ func TestViewEditFormRendersEnabledRow(t *testing.T) {
 func TestViewConfirmDialogRendered(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://gone", Type: "block"}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{Address: "https://gone", Type: "block"},
+	}
 	m.syncRows()
 	_, _ = m.Update(keyPress("x"))
 
@@ -272,7 +291,10 @@ func TestFormLeftRightTogglesTypeField(t *testing.T) {
 
 	// Assert
 	if m.form.listType != pihole.ListAllow {
-		t.Fatalf("left/right on the type field should toggle it, got %q", m.form.listType)
+		t.Fatalf(
+			"left/right on the type field should toggle it, got %q",
+			m.form.listType,
+		)
 	}
 }
 
@@ -289,7 +311,10 @@ func TestFormTypingEditsFocusedInput(t *testing.T) {
 
 	// Assert
 	if !strings.Contains(m.form.address.Value(), "z") {
-		t.Fatalf("typing should edit the focused input, got %q", m.form.address.Value())
+		t.Fatalf(
+			"typing should edit the focused input, got %q",
+			m.form.address.Value(),
+		)
 	}
 }
 
@@ -306,7 +331,14 @@ func TestFormCurrentDefaultsToTypeWhenOutOfRange(t *testing.T) {
 func TestSubmitFormEditClosureReturnsMutatedMsg(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.form = m.form.openEdit(pihole.List{Address: "https://a", Type: "block", Groups: []int{0}, Enabled: true})
+	m.form = m.form.openEdit(
+		pihole.List{
+			Address: "https://a",
+			Type:    "block",
+			Groups:  []int{0},
+			Enabled: true,
+		},
+	)
 	cmd := m.submitForm()
 	if cmd == nil {
 		t.Fatalf("edit submit should return an UpdateList cmd")
@@ -351,7 +383,9 @@ func TestToggleEnabledNoSelectionReturnsNil(t *testing.T) {
 func TestToggleEnabledClosureReturnsMutatedMsg(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.lists[pihole.ListBlock] = []pihole.List{{Address: "https://a", Type: "block", Enabled: true}}
+	m.lists[pihole.ListBlock] = []pihole.List{
+		{Address: "https://a", Type: "block", Enabled: true},
+	}
 	m.syncRows()
 	cmd := m.toggleEnabled()
 
@@ -376,7 +410,10 @@ func TestDeleteSelectedClosureReturnsMutatedMsg(t *testing.T) {
 
 	// Assert
 	if _, ok := msg.(mutatedMsg); !ok {
-		t.Fatalf("deleteSelected closure should yield a mutatedMsg, got %T", msg)
+		t.Fatalf(
+			"deleteSelected closure should yield a mutatedMsg, got %T",
+			msg,
+		)
 	}
 }
 
@@ -415,7 +452,10 @@ func TestRunGravityClosureAgainstCancelledContext(t *testing.T) {
 	// Assert
 	dm, ok := msg.(gravityDoneMsg)
 	if !ok {
-		t.Fatalf("runGravity closure should yield a gravityDoneMsg, got %T", msg)
+		t.Fatalf(
+			"runGravity closure should yield a gravityDoneMsg, got %T",
+			msg,
+		)
 	}
 	if dm.epoch != 7 {
 		t.Fatalf("runGravity should carry its epoch, got %d", dm.epoch)

--- a/internal/tui/screens/adlists/columns.go
+++ b/internal/tui/screens/adlists/columns.go
@@ -36,9 +36,17 @@ const (
 )
 
 // columnTitles is the header row, in render order.
-var columnTitles = []string{"Type", "Address", "Comment", "On", "Domains", "Status"}
+var columnTitles = []string{
+	"Type",
+	"Address",
+	"Comment",
+	"On",
+	"Domains",
+	"Status",
+}
 
-// computeColumnWidths returns the content width of each column for a given total
+// computeColumnWidths returns the content width of each column for a given
+// total
 // width. Widths never sum past the available (padding-adjusted) space, and each
 // flexible column is clamped to a sane minimum so nothing collapses.
 func computeColumnWidths(total int) []int {
@@ -58,7 +66,14 @@ func computeColumnWidths(total int) []int {
 	address = clampMin(address, minFlexCol)
 	comment = clampMin(comment, minFlexCol)
 
-	return []int{colTypeWidth, address, comment, colEnabledWidth, colDomainsWidth, colStatusWidth}
+	return []int{
+		colTypeWidth,
+		address,
+		comment,
+		colEnabledWidth,
+		colDomainsWidth,
+		colStatusWidth,
+	}
 }
 
 func clampMin(v, min int) int {
@@ -81,7 +96,8 @@ func tableColumns(widths []int) []table.Column {
 	return cols
 }
 
-// truncate shortens s to at most width display cells, appending an ellipsis when
+// truncate shortens s to at most width display cells, appending an ellipsis
+// when
 // it must cut. Rune-aware so multibyte addresses are not split mid-rune.
 func truncate(s string, width int) string {
 	if width <= 0 {
@@ -169,7 +185,8 @@ func listToRow(l pihole.List, widths []int) []string {
 	}
 }
 
-// styleForToken resolves a style token to a lipgloss style using the live theme.
+// styleForToken resolves a style token to a lipgloss style using the live
+// theme.
 func styleForToken(th *theme.Theme, token string) lipgloss.Style {
 	switch token {
 	case tokenBlock:
@@ -185,7 +202,11 @@ func styleForToken(th *theme.Theme, token string) lipgloss.Style {
 
 // styledRows builds table rows from lists, colouring the Type, On, and Status
 // cells by their tokens using the current theme. Read at View() time.
-func styledRows(th *theme.Theme, lists []pihole.List, widths []int) []table.Row {
+func styledRows(
+	th *theme.Theme,
+	lists []pihole.List,
+	widths []int,
+) []table.Row {
 	rows := make([]table.Row, len(lists))
 	for i, l := range lists {
 		cells := listToRow(l, widths)

--- a/internal/tui/screens/adlists/commands.go
+++ b/internal/tui/screens/adlists/commands.go
@@ -39,7 +39,14 @@ func (m *Model) submitForm() tea.Cmd {
 	groups := parseGroups(groupsVal)
 	return func() tea.Msg {
 		defer cancel()
-		_, err := api.UpdateList(ctx, address, listType, comment, groups, enabled)
+		_, err := api.UpdateList(
+			ctx,
+			address,
+			listType,
+			comment,
+			groups,
+			enabled,
+		)
 		return mutatedMsg{epoch: e, err: err}
 	}
 }

--- a/internal/tui/screens/adlists/form.go
+++ b/internal/tui/screens/adlists/form.go
@@ -212,28 +212,62 @@ func (f formModel) view(th *theme.Theme, width int) string {
 	if f.mode == formAdd {
 		addressField = f.address.View()
 	}
-	lines = append(lines, sel(fieldAddress)+" "+label.Render("Address")+addressField)
-	lines = append(lines, sel(fieldComment)+" "+label.Render("Comment")+f.comment.View())
-	lines = append(lines, sel(fieldGroups)+" "+label.Render("Groups")+f.groups.View())
+	lines = append(
+		lines,
+		sel(fieldAddress)+" "+label.Render("Address")+addressField,
+	)
+	lines = append(
+		lines,
+		sel(fieldComment)+" "+label.Render("Comment")+f.comment.View(),
+	)
+	lines = append(
+		lines,
+		sel(fieldGroups)+" "+label.Render("Groups")+f.groups.View(),
+	)
 
 	typeStyle := styleForToken(th, typeToken(string(f.listType)))
-	lines = append(lines, sel(fieldType)+" "+label.Render("Type")+typeStyle.Render(string(f.listType))+th.SubtleStyle().Render("  (←/→)"))
+	lines = append(
+		lines,
+		sel(
+			fieldType,
+		)+" "+label.Render(
+			"Type",
+		)+typeStyle.Render(
+			string(f.listType),
+		)+th.SubtleStyle().
+			Render("  (←/→)"),
+	)
 
 	if f.mode == formEdit {
 		enTok := tokenAllow
 		if !f.enabled {
 			enTok = tokenNeutral
 		}
-		lines = append(lines, sel(fieldEnabled)+" "+label.Render("Enabled")+styleForToken(th, enTok).Render(enabledCell(f.enabled)))
+		lines = append(
+			lines,
+			sel(
+				fieldEnabled,
+			)+" "+label.Render(
+				"Enabled",
+			)+styleForToken(
+				th,
+				enTok,
+			).Render(enabledCell(f.enabled)),
+		)
 	}
 
-	lines = append(lines, "", th.SubtleStyle().Render("tab next · ←/→ toggle · enter save · esc cancel"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().
+			Render("tab next · ←/→ toggle · enter save · esc cancel"),
+	)
 
 	panel := th.PanelStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(maxInt(minInt(width-2, 70), 24)).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 	return panel
 }

--- a/internal/tui/screens/adlists/gravity.go
+++ b/internal/tui/screens/adlists/gravity.go
@@ -31,7 +31,12 @@ type gravityDoneMsg struct {
 // pushing each progress line into ch and closing ch when the stream ends. It
 // returns a gravityDoneMsg carrying the terminal error (nil on success). The
 // caller is responsible for cancelling ctx (e.g. on Blur) to stop the stream.
-func runGravity(ctx context.Context, api *pihole.Client, ch chan string, epoch int) tea.Cmd {
+func runGravity(
+	ctx context.Context,
+	api *pihole.Client,
+	ch chan string,
+	epoch int,
+) tea.Cmd {
 	return func() tea.Msg {
 		err := api.UpdateGravity(ctx, func(line string) {
 			ch <- line

--- a/internal/tui/screens/adlists/keys.go
+++ b/internal/tui/screens/adlists/keys.go
@@ -75,7 +75,11 @@ func (m *Model) handleTableKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "g":
 		m.confirmKind = confirmGravity
-		m.confirm = m.confirm.Show("Run gravity update?", "Re-download and rebuild all adlists.", false)
+		m.confirm = m.confirm.Show(
+			"Run gravity update?",
+			"Re-download and rebuild all adlists.",
+			false,
+		)
 		return m, nil
 	}
 

--- a/internal/tui/screens/adlists/view.go
+++ b/internal/tui/screens/adlists/view.go
@@ -2,6 +2,7 @@ package adlists
 
 import (
 	"fmt"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -24,7 +25,7 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
@@ -56,7 +57,7 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	if m.err != nil {
 		second = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, second)
+	return strings.Join([]string{line, second}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -71,7 +72,14 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	}
 
 	if m.form.active {
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Top, m.form.view(th, m.w))
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Top,
+			m.form.view(th, m.w),
+			th.SurfaceWhitespace(),
+		)
 	}
 	if m.confirm.Active {
 		return m.confirm.Render(th, m.w, bodyH)
@@ -81,12 +89,28 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	}
 
 	if m.loading && len(m.lists[m.visible]) == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading lists…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading lists…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			th.SurfaceWhitespace(),
+		)
 	}
 	if len(m.lists[m.visible]) == 0 {
-		empty := th.SubtleStyle().Render("no " + string(m.visible) + " lists configured")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		empty := th.SubtleStyle().
+			Render("no " + string(m.visible) + " lists configured")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 	return m.table.View()
 }
@@ -95,9 +119,12 @@ func (m *Model) renderGravity(th *theme.Theme, bodyH int) string {
 	var status string
 	switch {
 	case m.gravityRunning:
-		status = m.spinner.View() + " " + th.SubtleStyle().Render(gravitySummary(false, nil))
+		status = m.spinner.View() + " " + th.SubtleStyle().
+			Render(gravitySummary(false, nil))
 	case m.gravityErr != nil:
-		status = th.BlockStyle().Bold(true).Render(gravitySummary(true, m.gravityErr))
+		status = th.BlockStyle().
+			Bold(true).
+			Render(gravitySummary(true, m.gravityErr))
 	default:
 		status = th.AllowStyle().Render(gravitySummary(true, nil))
 	}
@@ -107,10 +134,23 @@ func (m *Model) renderGravity(th *theme.Theme, bodyH int) string {
 	if !m.gravityRunning {
 		closeHint = th.SubtleStyle().Render("  esc close")
 	}
-	top := lipgloss.JoinHorizontal(lipgloss.Center, heading, "   ", status, closeHint)
+	top := lipgloss.JoinHorizontal(
+		lipgloss.Center,
+		heading,
+		"   ",
+		status,
+		closeHint,
+	)
 
-	body := lipgloss.JoinVertical(lipgloss.Left, top, m.viewport.View())
-	return lipgloss.Place(m.w, bodyH, lipgloss.Left, lipgloss.Top, body)
+	body := strings.Join([]string{top, m.viewport.View()}, "\n")
+	return lipgloss.Place(
+		m.w,
+		bodyH,
+		lipgloss.Left,
+		lipgloss.Top,
+		body,
+		th.SurfaceWhitespace(),
+	)
 }
 
 func (m *Model) renderFooter(th *theme.Theme) string {

--- a/internal/tui/screens/blocking/blocking.go
+++ b/internal/tui/screens/blocking/blocking.go
@@ -6,6 +6,7 @@ package blocking
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -19,7 +20,8 @@ import (
 
 const fetchTimeout = 8 * time.Second
 
-// action is one selectable row. secs semantics: enable=true re-enables blocking;
+// action is one selectable row. secs semantics: enable=true re-enables
+// blocking;
 // otherwise blocking is disabled for secs seconds (0 = indefinitely).
 type action struct {
 	label  string
@@ -161,9 +163,10 @@ func (m *Model) View() tea.View {
 	status := m.statusLine(th)
 	menu := m.renderMenu(th)
 
-	body := lipgloss.JoinVertical(lipgloss.Left, header, "", status, "", menu)
+	body := strings.Join([]string{header, "", status, "", menu}, "\n")
 	content := lipgloss.Place(m.w, m.h, lipgloss.Left, lipgloss.Top,
-		lipgloss.NewStyle().Padding(1, 2).Render(body))
+		lipgloss.NewStyle().Background(th.Surface).Padding(1, 2).Render(body),
+		th.SurfaceWhitespace())
 	return tea.NewView(th.SurfaceStyle().Width(m.w).Height(m.h).Render(content))
 }
 
@@ -187,8 +190,15 @@ func (m *Model) statusLine(th *theme.Theme) string {
 
 // renderMenu renders the action list with the cursor row highlighted.
 func (m *Model) renderMenu(th *theme.Theme) string {
-	sel := lipgloss.NewStyle().Foreground(th.Surface).Background(th.Accent).Bold(true).Padding(0, 1)
-	row := lipgloss.NewStyle().Foreground(th.Text).Padding(0, 1)
+	sel := lipgloss.NewStyle().
+		Foreground(th.Surface).
+		Background(th.Accent).
+		Bold(true).
+		Padding(0, 1)
+	row := lipgloss.NewStyle().
+		Foreground(th.Text).
+		Background(th.Surface).
+		Padding(0, 1)
 
 	lines := make([]string, len(actions))
 	for i, a := range actions {
@@ -202,7 +212,7 @@ func (m *Model) renderMenu(th *theme.Theme) string {
 			lines[i] = row.Render(marker + a.label)
 		}
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	return strings.Join(lines, "\n")
 }
 
 // humanCountdown formats seconds as a compact mm:ss / Ns countdown.

--- a/internal/tui/screens/blocking/blocking_test.go
+++ b/internal/tui/screens/blocking/blocking_test.go
@@ -15,29 +15,36 @@ import (
 	"github.com/zackkitzmiller/tihole/internal/tui/core"
 )
 
-// newModel builds a Blocking screen wired to an httptest FTL server. The handler
+// newModel builds a Blocking screen wired to an httptest FTL server. The
+// handler
 // answers the transparent /api/auth login plus GET/POST /api/dns/blocking. The
 // returned capture pointer records the last POST body so tests can assert the
 // timer/blocking values sent.
 func newModel(t *testing.T, get string) (*Model, *string) {
 	t.Helper()
 	var lastPost string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.HasSuffix(r.URL.Path, "/auth"):
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"session":{"valid":true,"sid":"s","csrf":"c","validity":1800,"totp":false},"took":0.1}`))
-		case strings.HasSuffix(r.URL.Path, "/dns/blocking"):
-			if r.Method == http.MethodPost {
-				b, _ := io.ReadAll(r.Body)
-				lastPost = string(b)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/auth"):
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(
+					[]byte(
+						`{"session":{"valid":true,"sid":"s","csrf":"c","validity":1800,"totp":false},"took":0.1}`,
+					),
+				)
+			case strings.HasSuffix(r.URL.Path, "/dns/blocking"):
+				if r.Method == http.MethodPost {
+					b, _ := io.ReadAll(r.Body)
+					lastPost = string(b)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(get))
+			default:
+				w.WriteHeader(http.StatusNotFound)
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(get))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
+		}),
+	)
 	t.Cleanup(srv.Close)
 
 	api := pihole.New(srv.URL, "pw", pihole.WithHTTPClient(srv.Client()))
@@ -87,7 +94,11 @@ func TestFocusFetchesStatus(t *testing.T) {
 
 	// Assert
 	if !m.known || !m.status.Blocking {
-		t.Fatalf("expected known+blocking status, got known=%v status=%+v", m.known, m.status)
+		t.Fatalf(
+			"expected known+blocking status, got known=%v status=%+v",
+			m.known,
+			m.status,
+		)
 	}
 }
 
@@ -205,8 +216,16 @@ func TestViewStates(t *testing.T) {
 		want string
 	}{
 		{"loading", func(m *Model) {}, "loading status"},
-		{"on", func(m *Model) { m.known = true; m.status = pihole.BlockingStatus{Blocking: true} }, "blocking is ON"},
-		{"off", func(m *Model) { m.known = true; m.status = pihole.BlockingStatus{Blocking: false} }, "blocking is OFF"},
+		{
+			"on",
+			func(m *Model) { m.known = true; m.status = pihole.BlockingStatus{Blocking: true} },
+			"blocking is ON",
+		},
+		{
+			"off",
+			func(m *Model) { m.known = true; m.status = pihole.BlockingStatus{Blocking: false} },
+			"blocking is OFF",
+		},
 		{"error", func(m *Model) { m.err = io.EOF }, "error"},
 	}
 	for _, tc := range cases {
@@ -231,13 +250,20 @@ func TestOffViewShowsCountdown(t *testing.T) {
 	m.known = true
 	m.status = pihole.BlockingStatus{Blocking: false, Timer: &secs}
 	out := m.View().Content
-	if !strings.Contains(out, "re-enables in") || !strings.Contains(out, "2m05s") {
+	if !strings.Contains(out, "re-enables in") ||
+		!strings.Contains(out, "2m05s") {
 		t.Fatalf("expected countdown in view, got: %s", out)
 	}
 }
 
 func TestHumanCountdown(t *testing.T) {
-	cases := map[int]string{-5: "0s", 0: "0s", 45: "45s", 60: "1m00s", 125: "2m05s"}
+	cases := map[int]string{
+		-5:  "0s",
+		0:   "0s",
+		45:  "45s",
+		60:  "1m00s",
+		125: "2m05s",
+	}
 	for in, want := range cases {
 		if got := humanCountdown(in); got != want {
 			t.Fatalf("humanCountdown(%d) = %q, want %q", in, got, want)

--- a/internal/tui/screens/clients/clients.go
+++ b/internal/tui/screens/clients/clients.go
@@ -44,7 +44,8 @@ type suggestionsMsg struct {
 	err         error
 }
 
-// mutationMsg carries the result of an add/update/delete, tagged with its epoch.
+// mutationMsg carries the result of an add/update/delete, tagged with its
+// epoch.
 type mutationMsg struct {
 	epoch int
 	err   error
@@ -101,7 +102,8 @@ func (m *Model) Init() tea.Cmd { return nil }
 func (m *Model) Title() string { return "Clients" }
 
 // CapturesInput reports whether the add/edit form is focused, so the root
-// delivers raw keys instead of firing global shortcuts (see core.InputCapturer).
+// delivers raw keys instead of firing global shortcuts (see
+// core.InputCapturer).
 func (m *Model) CapturesInput() bool { return m.form.active }
 
 // Focus activates the screen: bump the epoch and fetch a fresh client list.
@@ -298,6 +300,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) syncRows() {
 	widths := columnWidthsFrom(m.table.Columns())
 	idx := m.table.Cursor()
+	m.table.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.table.SetRows(clientRows(m.clients, widths))
 	m.table.SetCursor(idx)
 }
@@ -320,7 +323,7 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
@@ -339,7 +342,7 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	if m.err != nil {
 		second = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, second)
+	return strings.Join([]string{line, second}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -361,13 +364,29 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	}
 
 	if m.loading && len(m.clients) == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading clients…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading clients…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if len(m.clients) == 0 {
-		empty := th.SubtleStyle().Render("no clients configured — a to add, S for suggestions")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		empty := th.SubtleStyle().
+			Render("no clients configured — a to add, S for suggestions")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	return m.table.View()

--- a/internal/tui/screens/clients/clients_test.go
+++ b/internal/tui/screens/clients/clients_test.go
@@ -14,7 +14,9 @@ import (
 func newTestModel() *Model {
 	th := theme.DeepNight()
 	api := pihole.New("http://x", "pw")
-	return New(&core.AppContext{API: api, Theme: th, Keys: core.DefaultKeyMap()})
+	return New(
+		&core.AppContext{API: api, Theme: th, Keys: core.DefaultKeyMap()},
+	)
 }
 
 // key builds a KeyPressMsg for a single-character or named keystroke. Named
@@ -253,7 +255,9 @@ func TestUpdateIgnoresStaleClientsResult(t *testing.T) {
 	m.loading = true
 
 	// Act
-	_, _ = m.Update(clientsMsg{epoch: 8, clients: []pihole.ClientEntry{{Client: "x"}}})
+	_, _ = m.Update(
+		clientsMsg{epoch: 8, clients: []pihole.ClientEntry{{Client: "x"}}},
+	)
 
 	// Assert
 	if len(m.clients) != 0 {
@@ -338,7 +342,10 @@ func TestKeyXOpensDeleteConfirm(t *testing.T) {
 		t.Fatalf("`x` should open the confirm dialog")
 	}
 	if m.pendingDelete != "10.0.0.7" {
-		t.Fatalf("pending delete should hold the selected client: %q", m.pendingDelete)
+		t.Fatalf(
+			"pending delete should hold the selected client: %q",
+			m.pendingDelete,
+		)
 	}
 }
 
@@ -408,9 +415,16 @@ func TestSuggestionsMsgFillsPane(t *testing.T) {
 	m.suggest.loading = true
 
 	// Act
-	_, _ = m.Update(suggestionsMsg{epoch: 3, suggestions: []pihole.ClientSuggestion{
-		{Addresses: "10.0.0.5", Name: "phone", MACVendor: "Apple", LastQuery: 1_700_000_000},
-	}})
+	_, _ = m.Update(
+		suggestionsMsg{epoch: 3, suggestions: []pihole.ClientSuggestion{
+			{
+				Addresses: "10.0.0.5",
+				Name:      "phone",
+				MACVendor: "Apple",
+				LastQuery: 1_700_000_000,
+			},
+		}},
+	)
 
 	// Assert
 	if m.suggest.loading {
@@ -425,7 +439,9 @@ func TestSuggestionEnterPrefillsAddForm(t *testing.T) {
 	// Arrange
 	m := newTestModel()
 	m.suggest.active = true
-	m.suggest.suggestions = []pihole.ClientSuggestion{{Addresses: "10.0.0.5, 10.0.0.6"}}
+	m.suggest.suggestions = []pihole.ClientSuggestion{
+		{Addresses: "10.0.0.5, 10.0.0.6"},
+	}
 	m.suggest.cursor = 0
 
 	// Act
@@ -439,14 +455,21 @@ func TestSuggestionEnterPrefillsAddForm(t *testing.T) {
 		t.Fatalf("selecting a suggestion should open the add form")
 	}
 	if m.form.client.Value() != "10.0.0.5" {
-		t.Fatalf("add form should be pre-filled with the address, got %q", m.form.client.Value())
+		t.Fatalf(
+			"add form should be pre-filled with the address, got %q",
+			m.form.client.Value(),
+		)
 	}
 }
 
 func TestEditFormPreFillsAndFixesClient(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	c := pihole.ClientEntry{Client: "10.0.0.8", Comment: "nas", Groups: []int{0, 1}}
+	c := pihole.ClientEntry{
+		Client:  "10.0.0.8",
+		Comment: "nas",
+		Groups:  []int{0, 1},
+	}
 
 	// Act
 	m.openEditForm(c)
@@ -459,7 +482,10 @@ func TestEditFormPreFillsAndFixesClient(t *testing.T) {
 		t.Fatalf("edit form should carry the client id")
 	}
 	if m.form.groups.Value() != "0, 1" {
-		t.Fatalf("edit form should pre-fill groups, got %q", m.form.groups.Value())
+		t.Fatalf(
+			"edit form should pre-fill groups, got %q",
+			m.form.groups.Value(),
+		)
 	}
 	// In edit mode the client field is not focusable.
 	for _, f := range m.form.fields() {

--- a/internal/tui/screens/clients/clients_view_test.go
+++ b/internal/tui/screens/clients/clients_view_test.go
@@ -174,13 +174,21 @@ func TestViewSuggestionsStates(t *testing.T) {
 
 	// empty branch
 	m.suggest.err = nil
-	if out := m.View().Content; !strings.Contains(out, "no unconfigured clients") {
+	if out := m.View().Content; !strings.Contains(
+		out,
+		"no unconfigured clients",
+	) {
 		t.Fatalf("suggest empty should render label")
 	}
 
 	// populated branch (exercises rowLine + suggestionMeta + formatLastSeen)
 	m.suggest.suggestions = []pihole.ClientSuggestion{
-		{Addresses: "10.0.0.5", Name: "phone", MACVendor: "Apple", LastQuery: 1_700_000_000},
+		{
+			Addresses: "10.0.0.5",
+			Name:      "phone",
+			MACVendor: "Apple",
+			LastQuery: 1_700_000_000,
+		},
 		{Addresses: "10.0.0.6"},
 	}
 	m.suggest.cursor = 0

--- a/internal/tui/screens/clients/form.go
+++ b/internal/tui/screens/clients/form.go
@@ -145,18 +145,33 @@ func (f *clientForm) render(th *theme.Theme, w, h int) string {
 	)
 
 	if f.err != nil {
-		lines = append(lines, "", th.BlockStyle().Bold(true).Render("error: "+f.err.Error()))
+		lines = append(
+			lines,
+			"",
+			th.BlockStyle().Bold(true).Render("error: "+f.err.Error()),
+		)
 	}
-	lines = append(lines, "", th.SubtleStyle().Render("tab next · enter save · esc cancel"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().Render("tab next · enter save · esc cancel"),
+	)
 
 	panel := th.PanelStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(th.Accent).
 		Padding(1, 2).
 		Width(maxInt(minInt(w-2, 64), 24)).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		w,
+		h,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		th.SurfaceWhitespace(),
+	)
 }
 
 // formValues extracts the trimmed, parsed field values for submission.

--- a/internal/tui/screens/clients/suggestions.go
+++ b/internal/tui/screens/clients/suggestions.go
@@ -47,35 +47,63 @@ func (s *suggestState) moveDown() {
 // candidate address, its resolved name, MAC vendor, and last-seen time.
 func (s *suggestState) render(th *theme.Theme, spin string, w, h int) string {
 	var lines []string
-	lines = append(lines, th.AccentStyle().Bold(true).Render("Client suggestions"), "")
+	lines = append(
+		lines,
+		th.AccentStyle().Bold(true).Render("Client suggestions"),
+		"",
+	)
 
 	switch {
 	case s.loading:
-		lines = append(lines, th.SubtleStyle().Render(spin+" loading suggestions…"))
+		lines = append(
+			lines,
+			th.SubtleStyle().Render(spin+" loading suggestions…"),
+		)
 	case s.err != nil:
-		lines = append(lines, th.BlockStyle().Bold(true).Render("error: "+s.err.Error()))
+		lines = append(
+			lines,
+			th.BlockStyle().Bold(true).Render("error: "+s.err.Error()),
+		)
 	case len(s.suggestions) == 0:
-		lines = append(lines, th.SubtleStyle().Render("no unconfigured clients seen"))
+		lines = append(
+			lines,
+			th.SubtleStyle().Render("no unconfigured clients seen"),
+		)
 	default:
 		for i, sg := range s.suggestions {
 			lines = append(lines, s.rowLine(th, i, sg))
 		}
 	}
 
-	lines = append(lines, "", th.SubtleStyle().Render("↑↓ move · enter add · esc close"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().Render("↑↓ move · enter add · esc close"),
+	)
 
 	panel := th.PanelStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(th.Accent).
 		Padding(1, 2).
 		Width(maxInt(minInt(w-2, 72), 24)).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		w,
+		h,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		th.SurfaceWhitespace(),
+	)
 }
 
 // rowLine formats one suggestion, marking the cursor row with the accent color.
-func (s *suggestState) rowLine(th *theme.Theme, i int, sg pihole.ClientSuggestion) string {
+func (s *suggestState) rowLine(
+	th *theme.Theme,
+	i int,
+	sg pihole.ClientSuggestion,
+) string {
 	addr := orDash(firstAddress(sg.Addresses))
 	meta := suggestionMeta(sg)
 

--- a/internal/tui/screens/dashboard/dashboard.go
+++ b/internal/tui/screens/dashboard/dashboard.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"image/color"
 	"sort"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -145,6 +146,11 @@ func (m *Model) buildGauges() {
 		progress.WithColors(th.Accent, th.Allow),
 		progress.WithoutPercentage(),
 	)
+	// The default empty-track color is a hardcoded slate gray (#606060) that
+	// reads as a bleed-through rectangle against the themed panel. Repaint it
+	// with the theme's border color so the unfilled track stays a subtle,
+	// on-palette hairline.
+	m.blockBar.EmptyColor = th.Border
 	m.cpuBar = newHealthGauge(th)
 	m.memBar = newHealthGauge(th)
 	m.tempBar = newHealthGauge(th)
@@ -155,7 +161,7 @@ func (m *Model) buildGauges() {
 // calm (allow) under 60%, warn (amber) under 85%, hot (block) above.
 func newHealthGauge(th *theme.Theme) progress.Model {
 	allow, warn, block := th.Allow, th.Warn, th.Block
-	return progress.New(
+	g := progress.New(
 		progress.WithoutPercentage(),
 		progress.WithColorFunc(func(total, _ float64) color.Color {
 			switch {
@@ -168,6 +174,10 @@ func newHealthGauge(th *theme.Theme) progress.Model {
 			}
 		}),
 	)
+	// Repaint the default slate-gray empty track (see buildGauges) so the
+	// unfilled portion blends with the panel instead of bleeding gray.
+	g.EmptyColor = th.Border
+	return g
 }
 
 // syncBarTheme rebuilds every gauge when the active theme changes (the Auto
@@ -209,7 +219,12 @@ func (m *Model) applySystem(msg systemMsg) tea.Cmd {
 		m.memBar.SetPercent(clampFrac(m.system.MemUsedPercent / 100)),
 	}
 	if m.sensors.HasTemp && m.sensors.HotLimit > 0 {
-		cmds = append(cmds, m.tempBar.SetPercent(clampFrac(m.sensors.CPUTemp/m.sensors.HotLimit)))
+		cmds = append(
+			cmds,
+			m.tempBar.SetPercent(
+				clampFrac(m.sensors.CPUTemp/m.sensors.HotLimit),
+			),
+		)
 	}
 	return tea.Batch(cmds...)
 }
@@ -234,7 +249,8 @@ func (m *Model) Title() string { return "Dashboard" }
 
 // Interactive reports false: the dashboard is a read-only overview with nothing
 // to select or edit, so the nav rail never descends into it (see
-// core.PanelInteractor). This keeps enter/tab/→ from dropping focus into a panel
+// core.PanelInteractor). This keeps enter/tab/→ from dropping focus into a
+// panel
 // where no key would do anything.
 func (m *Model) Interactive() bool { return false }
 
@@ -427,13 +443,23 @@ func fetchHistory(base context.Context, api *pihole.Client, epoch int) tea.Cmd {
 	}
 }
 
-func fetchBreakdown(base context.Context, api *pihole.Client, epoch int) tea.Cmd {
+func fetchBreakdown(
+	base context.Context,
+	api *pihole.Client,
+	epoch int,
+) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(base, fetchTimeout)
 		defer cancel()
 		types, tErr := api.QueryTypes(ctx)
 		up, uErr := api.Upstreams(ctx)
-		return breakdownMsg{epoch: epoch, types: types, upstreams: up, typesErr: tErr, upErr: uErr}
+		return breakdownMsg{
+			epoch:     epoch,
+			types:     types,
+			upstreams: up,
+			typesErr:  tErr,
+			upErr:     uErr,
+		}
 	}
 }
 
@@ -475,7 +501,8 @@ func fetchTop(base context.Context, api *pihole.Client, epoch int) tea.Cmd {
 	}
 }
 
-// sortedTypes returns query-type entries sorted by descending count for a stable
+// sortedTypes returns query-type entries sorted by descending count for a
+// stable
 // breakdown render (Go map order is otherwise random). Extracted for testing.
 func sortedTypes(types map[string]int) []labeledCount {
 	out := make([]labeledCount, 0, len(types))
@@ -506,7 +533,8 @@ func (m *Model) View() tea.View {
 	}
 
 	if !m.loaded {
-		msg := m.spinner.View() + " " + th.SubtleStyle().Render("Loading dashboard…")
+		msg := m.spinner.View() + " " + th.SubtleStyle().
+			Render("Loading dashboard…")
 		body := lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, msg)
 		return tea.NewView(surface.Render(body))
 	}
@@ -517,6 +545,10 @@ func (m *Model) View() tea.View {
 		m.renderSparkline(),
 		m.renderLower(),
 	}
-	body := lipgloss.JoinVertical(lipgloss.Left, sections...)
+	// strings.Join (not JoinVertical) so the surface wrapper repaints each
+	// line's right padding with the surface background: JoinVertical would
+	// pre-pad narrower sections with bare spaces that bleed the terminal
+	// background.
+	body := strings.Join(sections, "\n")
 	return tea.NewView(surface.Render(body))
 }

--- a/internal/tui/screens/dashboard/dashboard_test.go
+++ b/internal/tui/screens/dashboard/dashboard_test.go
@@ -138,7 +138,13 @@ func TestMiniBar_HalfFractionFillsHalf(t *testing.T) {
 	got := miniBar(0.5, 10)
 
 	// Assert
-	want := strings.Repeat(string(barFilled), 5) + strings.Repeat(string(barEmpty), 5)
+	want := strings.Repeat(
+		string(barFilled),
+		5,
+	) + strings.Repeat(
+		string(barEmpty),
+		5,
+	)
 	if got != want {
 		t.Fatalf("expected half-filled bar %q, got %q", want, got)
 	}
@@ -255,7 +261,10 @@ func TestUpdate_StaleResultIsDiscarded(t *testing.T) {
 
 	// Assert
 	if m.errSummary != "" {
-		t.Fatalf("stale summary result should be ignored, got err %q", m.errSummary)
+		t.Fatalf(
+			"stale summary result should be ignored, got err %q",
+			m.errSummary,
+		)
 	}
 	if m.loaded {
 		t.Fatal("stale result should not mark model as loaded")

--- a/internal/tui/screens/dashboard/format.go
+++ b/internal/tui/screens/dashboard/format.go
@@ -10,7 +10,8 @@ const (
 )
 
 // miniBar renders a horizontal meter width runes wide, filled proportionally to
-// fraction (clamped to 0..1). A width <= 0 yields "". The fraction is rounded to
+// fraction (clamped to 0..1). A width <= 0 yields "". The fraction is rounded
+// to
 // the nearest cell so a small non-zero value still shows at least one filled
 // cell once it rounds up.
 func miniBar(fraction float64, width int) string {
@@ -77,7 +78,8 @@ func formatCount(n int) string {
 }
 
 // formatPercent renders a 0..100 percentage with one decimal place and a
-// trailing '%' (e.g. 42.15 -> "42.2%"). Values are not clamped; callers pass the
+// trailing '%' (e.g. 42.15 -> "42.2%"). Values are not clamped; callers pass
+// the
 // API-provided percent directly.
 func formatPercent(p float64) string {
 	return strconv.FormatFloat(p, 'f', 1, 64) + "%"

--- a/internal/tui/screens/dashboard/health.go
+++ b/internal/tui/screens/dashboard/health.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"fmt"
+	"strings"
 
 	"charm.land/bubbles/v2/progress"
 	"charm.land/lipgloss/v2"
@@ -28,7 +29,12 @@ func (m *Model) renderHealth() string {
 	}
 
 	cells := []string{
-		m.gaugeCell("CPU", fmt.Sprintf("%.1f%%", m.system.CPUPercent), &m.cpuBar, inner),
+		m.gaugeCell(
+			"CPU",
+			fmt.Sprintf("%.1f%%", m.system.CPUPercent),
+			&m.cpuBar,
+			inner,
+		),
 		m.gaugeCell("Memory", memLabel(m.system), &m.memBar, inner),
 		m.tempCell(inner),
 		m.loadCell(inner),
@@ -38,12 +44,16 @@ func (m *Model) renderHealth() string {
 }
 
 // gaugeCell renders a labeled animated gauge with a value line above it.
-func (m *Model) gaugeCell(label, value string, bar *progress.Model, inner int) string {
+func (m *Model) gaugeCell(
+	label, value string,
+	bar *progress.Model,
+	inner int,
+) string {
 	th := m.ctx.Theme
 	lbl := th.SubtleStyle().Render(truncate(label, inner))
 	val := th.TextStyle().Bold(true).Render(truncate(value, inner))
 	bar.SetWidth(inner)
-	body := lipgloss.JoinVertical(lipgloss.Left, lbl, val, bar.View())
+	body := strings.Join([]string{lbl, val, bar.View()}, "\n")
 	return panelBox(th).Width(inner).Render(body)
 }
 
@@ -52,10 +62,11 @@ func (m *Model) gaugeCell(label, value string, bar *progress.Model, inner int) s
 func (m *Model) tempCell(inner int) string {
 	th := m.ctx.Theme
 	if !m.sensors.HasTemp {
-		body := lipgloss.JoinVertical(lipgloss.Left,
+		body := strings.Join([]string{
 			th.SubtleStyle().Render("Temp"),
 			th.SubtleStyle().Render("n/a"),
-			th.SubtleStyle().Render("no sensor"))
+			th.SubtleStyle().Render("no sensor"),
+		}, "\n")
 		return panelBox(th).Width(inner).Render(body)
 	}
 	unit := m.sensors.Unit
@@ -70,10 +81,18 @@ func (m *Model) tempCell(inner int) string {
 func (m *Model) loadCell(inner int) string {
 	th := m.ctx.Theme
 	lbl := th.SubtleStyle().Render("Load · Up")
-	load := th.TextStyle().Bold(true).Render(truncate(fmt.Sprintf("%.1f%%", m.system.Load1Percent), inner))
+	load := th.TextStyle().
+		Bold(true).
+		Render(truncate(fmt.Sprintf("%.1f%%", m.system.Load1Percent), inner))
 	sub := th.SubtleStyle().Render(truncate(
-		fmt.Sprintf("%dp · %s", m.system.Procs, humanUptime(m.system.Uptime)), inner))
-	body := lipgloss.JoinVertical(lipgloss.Left, lbl, load, sub)
+		fmt.Sprintf(
+			"%dp · %s",
+			m.system.Procs,
+			humanUptime(m.system.Uptime),
+		),
+		inner,
+	))
+	body := strings.Join([]string{lbl, load, sub}, "\n")
 	return panelBox(th).Width(inner).Render(body)
 }
 
@@ -87,16 +106,21 @@ func (m *Model) diagnosticsCell(inner int) string {
 	case m.errMessages != "":
 		val := th.WarnStyle().Bold(true).Render("? unknown")
 		sub := th.SubtleStyle().Render(truncate(m.errMessages, inner))
-		return panelBox(th).Width(inner).Render(lipgloss.JoinVertical(lipgloss.Left, lbl, val, sub))
+		body := strings.Join([]string{lbl, val, sub}, "\n")
+		return panelBox(th).Width(inner).Render(body)
 
 	case len(m.messages) == 0:
 		val := th.AllowStyle().Bold(true).Render("✓ All clear")
 		sub := th.SubtleStyle().Render("0 messages")
-		return panelBox(th).Width(inner).Render(lipgloss.JoinVertical(lipgloss.Left, lbl, val, sub))
+		body := strings.Join([]string{lbl, val, sub}, "\n")
+		return panelBox(th).Width(inner).Render(body)
 
 	default:
-		val := th.WarnStyle().Bold(true).Render(truncate(pluralIssues(len(m.messages)), inner))
+		val := th.WarnStyle().
+			Bold(true).
+			Render(truncate(pluralIssues(len(m.messages)), inner))
 		sub := th.BlockStyle().Render(truncate(m.messages[0].Plain, inner))
-		return panelBox(th).Width(inner).Render(lipgloss.JoinVertical(lipgloss.Left, lbl, val, sub))
+		body := strings.Join([]string{lbl, val, sub}, "\n")
+		return panelBox(th).Width(inner).Render(body)
 	}
 }

--- a/internal/tui/screens/dashboard/health_test.go
+++ b/internal/tui/screens/dashboard/health_test.go
@@ -57,7 +57,12 @@ func TestRenderHealth_TemperatureShownWithSensor(t *testing.T) {
 	// Arrange
 	m := newTestModel()
 	m.system = sampleSystem()
-	m.sensors = pihole.Sensors{HasTemp: true, CPUTemp: 48.2, HotLimit: 60, Unit: "C"}
+	m.sensors = pihole.Sensors{
+		HasTemp:  true,
+		CPUTemp:  48.2,
+		HotLimit: 60,
+		Unit:     "C",
+	}
 
 	// Act
 	out := m.renderHealth()
@@ -122,7 +127,11 @@ func TestApplySystem_SpringsGaugesAndRecordsErrorsIndependently(t *testing.T) {
 	// Arrange
 	m := newTestModel()
 	msg := systemMsg{
-		system:  pihole.SystemInfo{CPUPercent: 50, MemUsedPercent: 25, NProcs: 4},
+		system: pihole.SystemInfo{
+			CPUPercent:     50,
+			MemUsedPercent: 25,
+			NProcs:         4,
+		},
 		sensors: pihole.Sensors{HasTemp: true, CPUTemp: 30, HotLimit: 60},
 		msgErr:  errors.New("boom"),
 	}

--- a/internal/tui/screens/dashboard/healthfmt.go
+++ b/internal/tui/screens/dashboard/healthfmt.go
@@ -11,7 +11,12 @@ import (
 func memLabel(s pihole.SystemInfo) string {
 	pct := fmt.Sprintf("%.1f%%", s.MemUsedPercent)
 	if s.MemTotalKiB > 0 {
-		return fmt.Sprintf("%s · %s/%s", pct, humanKiB(s.MemUsedKiB), humanKiB(s.MemTotalKiB))
+		return fmt.Sprintf(
+			"%s · %s/%s",
+			pct,
+			humanKiB(s.MemUsedKiB),
+			humanKiB(s.MemTotalKiB),
+		)
 	}
 	return pct
 }
@@ -35,7 +40,8 @@ func humanUptime(seconds int64) string {
 	}
 }
 
-// humanKiB renders a kibibyte figure (as FTL reports memory) in the largest unit
+// humanKiB renders a kibibyte figure (as FTL reports memory) in the largest
+// unit
 // that keeps it readable: KiB, MiB or GiB.
 func humanKiB(kib int64) string {
 	const (

--- a/internal/tui/screens/dashboard/healthfmt_test.go
+++ b/internal/tui/screens/dashboard/healthfmt_test.go
@@ -24,7 +24,12 @@ func TestHumanUptime(t *testing.T) {
 			got := humanUptime(tc.seconds)
 			// Assert
 			if got != tc.want {
-				t.Errorf("humanUptime(%d) = %q, want %q", tc.seconds, got, tc.want)
+				t.Errorf(
+					"humanUptime(%d) = %q, want %q",
+					tc.seconds,
+					got,
+					tc.want,
+				)
 			}
 		})
 	}
@@ -54,7 +59,11 @@ func TestHumanKiB(t *testing.T) {
 
 func TestMemLabelIncludesTotalsWhenKnown(t *testing.T) {
 	// Arrange
-	s := pihole.SystemInfo{MemUsedPercent: 6.787, MemUsedKiB: 263808, MemTotalKiB: 3886904}
+	s := pihole.SystemInfo{
+		MemUsedPercent: 6.787,
+		MemUsedKiB:     263808,
+		MemTotalKiB:    3886904,
+	}
 
 	// Act
 	got := memLabel(s)

--- a/internal/tui/screens/dashboard/model_test.go
+++ b/internal/tui/screens/dashboard/model_test.go
@@ -191,16 +191,28 @@ func TestUpdate_BreakdownResultStoresBothAndErrors(t *testing.T) {
 	m.epoch = 3
 
 	// Act: success path populates both
-	m.Update(breakdownMsg{epoch: 3, types: sampleTypes(), upstreams: sampleUpstreams()})
+	m.Update(
+		breakdownMsg{
+			epoch:     3,
+			types:     sampleTypes(),
+			upstreams: sampleUpstreams(),
+		},
+	)
 	if len(m.types.Types) == 0 || len(m.upstreams.Upstreams) == 0 {
 		t.Fatal("breakdown success should populate both fields")
 	}
 	// Act: error path sets both banners
-	m.Update(breakdownMsg{epoch: 3, typesErr: errStub("t"), upErr: errStub("u")})
+	m.Update(
+		breakdownMsg{epoch: 3, typesErr: errStub("t"), upErr: errStub("u")},
+	)
 
 	// Assert
 	if m.errTypes != "t" || m.errUpstreams != "u" {
-		t.Fatalf("expected both breakdown errors, got %q / %q", m.errTypes, m.errUpstreams)
+		t.Fatalf(
+			"expected both breakdown errors, got %q / %q",
+			m.errTypes,
+			m.errUpstreams,
+		)
 	}
 }
 
@@ -224,16 +236,35 @@ func TestUpdate_TopResultStoresAllAndErrors(t *testing.T) {
 	m.epoch = 3
 
 	// Act: success
-	m.Update(topMsg{epoch: 3, domains: sampleTopDomains(), blocked: sampleTopDomains(), clients: sampleTopClients()})
+	m.Update(
+		topMsg{
+			epoch:   3,
+			domains: sampleTopDomains(),
+			blocked: sampleTopDomains(),
+			clients: sampleTopClients(),
+		},
+	)
 	if len(m.domains.Domains) == 0 || len(m.clients.Clients) == 0 {
 		t.Fatal("top success should populate lists")
 	}
 	// Act: errors
-	m.Update(topMsg{epoch: 3, domainsErr: errStub("d"), blockedErr: errStub("b"), clientsErr: errStub("c")})
+	m.Update(
+		topMsg{
+			epoch:      3,
+			domainsErr: errStub("d"),
+			blockedErr: errStub("b"),
+			clientsErr: errStub("c"),
+		},
+	)
 
 	// Assert
 	if m.errDomains != "d" || m.errBlocked != "b" || m.errClients != "c" {
-		t.Fatalf("expected all top errors set, got %q/%q/%q", m.errDomains, m.errBlocked, m.errClients)
+		t.Fatalf(
+			"expected all top errors set, got %q/%q/%q",
+			m.errDomains,
+			m.errBlocked,
+			m.errClients,
+		)
 	}
 }
 
@@ -373,14 +404,19 @@ func TestUpdate_ProgressFrameAdvancesGauge(t *testing.T) {
 }
 
 // TestSyncBarTheme_RebuildsOnThemeChangePreservingPercent verifies the gauge is
-// rebuilt when the active theme changes, keeping its target percent so the value
+// rebuilt when the active theme changes, keeping its target percent so the
+// value
 // doesn't jump, and is left untouched when the theme is unchanged.
 func TestSyncBarTheme_RebuildsOnThemeChangePreservingPercent(t *testing.T) {
 	// Arrange: give the gauge a target, then swap the theme.
 	m := newTestModel()
 	m.blockBar.SetPercent(0.42)
 	if m.barTheme != theme.DeepNight().Name {
-		t.Fatalf("precondition: gauge built for %q, got %q", theme.DeepNight().Name, m.barTheme)
+		t.Fatalf(
+			"precondition: gauge built for %q, got %q",
+			theme.DeepNight().Name,
+			m.barTheme,
+		)
 	}
 	m.ctx.Theme = theme.LightLuxury()
 
@@ -389,10 +425,17 @@ func TestSyncBarTheme_RebuildsOnThemeChangePreservingPercent(t *testing.T) {
 
 	// Assert: rebuilt for the new theme, percent preserved.
 	if m.barTheme != theme.LightLuxury().Name {
-		t.Fatalf("expected gauge rebuilt for %q, got %q", theme.LightLuxury().Name, m.barTheme)
+		t.Fatalf(
+			"expected gauge rebuilt for %q, got %q",
+			theme.LightLuxury().Name,
+			m.barTheme,
+		)
 	}
 	if got := m.blockBar.Percent(); got < 0.41 || got > 0.43 {
-		t.Fatalf("percent not preserved across rebuild: got %.3f want ~0.42", got)
+		t.Fatalf(
+			"percent not preserved across rebuild: got %.3f want ~0.42",
+			got,
+		)
 	}
 
 	// Act again with no change: barTheme stays put (no needless rebuild).

--- a/internal/tui/screens/dashboard/render.go
+++ b/internal/tui/screens/dashboard/render.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"fmt"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 
@@ -9,7 +10,8 @@ import (
 	"github.com/zackkitzmiller/tihole/internal/theme"
 )
 
-// truncate shortens s to at most width display cells, appending an ellipsis when
+// truncate shortens s to at most width display cells, appending an ellipsis
+// when
 // it has to cut. A width <= 0 yields "".
 func truncate(s string, width int) string {
 	if width <= 0 {
@@ -25,11 +27,18 @@ func truncate(s string, width int) string {
 	return string(r[:width-1]) + "…"
 }
 
-// panelBox is the shared bordered surface for every dashboard panel.
+// panelBox is the shared bordered surface for every dashboard panel. It carries
+// the raised Panel background explicitly: without it, the card interior and the
+// spaces JoinVertical adds to equalize line widths sit after a styled run's
+// reset and paint in the terminal's own background, bleeding through as gray
+// gaps under and after text.
 func panelBox(th *theme.Theme) lipgloss.Style {
 	return lipgloss.NewStyle().
+		Background(th.Panel).
+		Foreground(th.Text).
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(th.Border).
+		BorderBackground(th.Surface).
 		Padding(0, 1)
 }
 
@@ -47,15 +56,29 @@ func (m *Model) renderTiles() string {
 		m.tile("Total Queries", formatCount(m.summary.Queries.Total), inner),
 		m.blockedTile(inner),
 		m.tile("Active Clients", formatCount(m.summary.Clients.Active), inner),
-		m.tile("Gravity Domains", formatCount(m.summary.Gravity.DomainsBeingBlocked), inner),
+		m.tile(
+			"Gravity Domains",
+			formatCount(m.summary.Gravity.DomainsBeingBlocked),
+			inner,
+		),
 	}
 
 	if m.errSummary != "" {
 		return panelBox(th).Width(m.w - 4).Render(
-			th.BlockStyle().Render("summary unavailable: ") + th.SubtleStyle().Render(truncate(m.errSummary, m.w-24)))
+			th.BlockStyle().
+				Render("summary unavailable: ") +
+				th.SubtleStyle().
+					Render(truncate(m.errSummary, m.w-24)),
+		)
 	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, tiles...)
+	// The Blocked tile carries a gauge line the others lack, so equalize
+	// heights first to keep JoinHorizontal from bleeding under the shorter
+	// tiles.
+	return lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		equalizeHeights(th, tiles...)...,
+	)
 }
 
 // blockedTile is the Blocked stat tile with an animated gradient gauge beneath
@@ -74,7 +97,7 @@ func (m *Model) blockedTile(inner int) string {
 	m.blockBar.SetWidth(inner)
 	gauge := m.blockBar.View()
 
-	body := lipgloss.JoinVertical(lipgloss.Left, lbl, fig, gauge)
+	body := strings.Join([]string{lbl, fig, gauge}, "\n")
 	return panelBox(th).Width(inner).Render(body)
 }
 
@@ -83,7 +106,7 @@ func (m *Model) tile(label, value string, inner int) string {
 	th := m.ctx.Theme
 	lbl := th.SubtleStyle().Render(truncate(label, inner))
 	fig := th.AccentStyle().Bold(true).Render(truncate(value, inner))
-	body := lipgloss.JoinVertical(lipgloss.Left, lbl, fig)
+	body := strings.Join([]string{lbl, fig}, "\n")
 	return panelBox(th).Width(inner).Render(body)
 }
 
@@ -100,7 +123,8 @@ func (m *Model) renderSparkline() string {
 	var line string
 	switch {
 	case m.errHistory != "":
-		line = th.BlockStyle().Render(truncate("history unavailable: "+m.errHistory, inner))
+		line = th.BlockStyle().
+			Render(truncate("history unavailable: "+m.errHistory, inner))
 	case len(m.history.History) == 0:
 		line = th.SubtleStyle().Render("no history yet")
 	default:
@@ -112,11 +136,15 @@ func (m *Model) renderSparkline() string {
 		}
 		totalLine := th.AccentStyle().Render(sparklineInt(totals, inner))
 		blockedLine := th.BlockStyle().Render(sparklineInt(blocked, inner))
-		legend := th.SubtleStyle().Render(fmt.Sprintf("total (accent) / blocked  —  %d buckets", len(m.history.History)))
-		line = lipgloss.JoinVertical(lipgloss.Left, totalLine, blockedLine, legend)
+		legend := th.SubtleStyle().
+			Render(fmt.Sprintf("total (accent) / blocked  —  %d buckets", len(m.history.History)))
+		line = strings.Join(
+			[]string{totalLine, blockedLine, legend},
+			"\n",
+		)
 	}
 
-	body := lipgloss.JoinVertical(lipgloss.Left, title, line)
+	body := strings.Join([]string{title, line}, "\n")
 	return panelBox(th).Width(inner).Render(body)
 }
 
@@ -128,30 +156,82 @@ func (m *Model) renderLower() string {
 		inner = 6
 	}
 
-	col1 := lipgloss.JoinVertical(lipgloss.Left,
-		m.breakdownPanel("Query Types", typeItems(m.types.Types), m.errTypes, inner),
-		m.breakdownPanel("Upstreams", upstreamItems(m.upstreams.Upstreams), m.errUpstreams, inner),
+	col1 := lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.breakdownPanel(
+			"Query Types",
+			typeItems(m.types.Types),
+			m.errTypes,
+			inner,
+		),
+		m.breakdownPanel(
+			"Upstreams",
+			upstreamItems(m.upstreams.Upstreams),
+			m.errUpstreams,
+			inner,
+		),
 	)
 	col2 := lipgloss.JoinVertical(lipgloss.Left,
 		m.listPanel("Top Domains", domainItems(m.domains), m.errDomains, inner),
 		m.listPanel("Top Blocked", domainItems(m.blocked), m.errBlocked, inner),
 	)
-	col3 := m.listPanel("Top Clients", clientItems(m.clients), m.errClients, inner)
+	col3 := m.listPanel(
+		"Top Clients",
+		clientItems(m.clients),
+		m.errClients,
+		inner,
+	)
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, col1, col2, col3)
+	// JoinHorizontal pads the shorter column with bare (unstyled) lines, which
+	// would bleed the terminal background beneath it. Equalize every column to
+	// the tallest one first, filling with the surface color.
+	cols := equalizeHeights(m.ctx.Theme, col1, col2, col3)
+	return lipgloss.JoinHorizontal(lipgloss.Top, cols...)
+}
+
+// equalizeHeights pads each block to the tallest block's height, filling the
+// added lines with the surface background so a short column can't bleed the
+// terminal background where JoinHorizontal would otherwise insert blank cells.
+func equalizeHeights(th *theme.Theme, blocks ...string) []string {
+	maxH := 0
+	for _, b := range blocks {
+		if h := lipgloss.Height(b); h > maxH {
+			maxH = h
+		}
+	}
+	out := make([]string, len(blocks))
+	for i, b := range blocks {
+		out[i] = lipgloss.NewStyle().
+			Background(th.Surface).
+			Width(lipgloss.Width(b)).
+			Height(maxH).
+			Render(b)
+	}
+	return out
 }
 
 // breakdownPanel renders labeled counts as mini horizontal bars.
-func (m *Model) breakdownPanel(title string, items []labeledCount, errStr string, inner int) string {
+func (m *Model) breakdownPanel(
+	title string,
+	items []labeledCount,
+	errStr string,
+	inner int,
+) string {
 	th := m.ctx.Theme
 	head := th.TextStyle().Bold(true).Render(truncate(title, inner))
 
 	if errStr != "" {
-		body := lipgloss.JoinVertical(lipgloss.Left, head, th.BlockStyle().Render(truncate(errStr, inner)))
+		body := strings.Join(
+			[]string{head, th.BlockStyle().Render(truncate(errStr, inner))},
+			"\n",
+		)
 		return panelBox(th).Width(inner).Render(body)
 	}
 	if len(items) == 0 {
-		body := lipgloss.JoinVertical(lipgloss.Left, head, th.SubtleStyle().Render("no data"))
+		body := strings.Join(
+			[]string{head, th.SubtleStyle().Render("no data")},
+			"\n",
+		)
 		return panelBox(th).Width(inner).Render(body)
 	}
 
@@ -175,25 +255,37 @@ func (m *Model) breakdownPanel(title string, items []labeledCount, errStr string
 		if max > 0 {
 			frac = float64(it.count) / float64(max)
 		}
-		label := th.SubtleStyle().Render(padRight(truncate(it.label, labelW), labelW))
+		label := th.SubtleStyle().
+			Render(padRight(truncate(it.label, labelW), labelW))
 		bar := th.AccentStyle().Render(miniBar(frac, barW))
 		count := th.TextStyle().Render(padLeft(formatCount(it.count), countW))
 		rows = append(rows, fmt.Sprintf("%s %s %s", label, bar, count))
 	}
-	return panelBox(th).Width(inner).Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+	return panelBox(th).Width(inner).Render(strings.Join(rows, "\n"))
 }
 
 // listPanel renders a ranked label/count list.
-func (m *Model) listPanel(title string, items []labeledCount, errStr string, inner int) string {
+func (m *Model) listPanel(
+	title string,
+	items []labeledCount,
+	errStr string,
+	inner int,
+) string {
 	th := m.ctx.Theme
 	head := th.TextStyle().Bold(true).Render(truncate(title, inner))
 
 	if errStr != "" {
-		body := lipgloss.JoinVertical(lipgloss.Left, head, th.BlockStyle().Render(truncate(errStr, inner)))
+		body := strings.Join(
+			[]string{head, th.BlockStyle().Render(truncate(errStr, inner))},
+			"\n",
+		)
 		return panelBox(th).Width(inner).Render(body)
 	}
 	if len(items) == 0 {
-		body := lipgloss.JoinVertical(lipgloss.Left, head, th.SubtleStyle().Render("no data"))
+		body := strings.Join(
+			[]string{head, th.SubtleStyle().Render("no data")},
+			"\n",
+		)
 		return panelBox(th).Width(inner).Render(body)
 	}
 
@@ -210,11 +302,12 @@ func (m *Model) listPanel(title string, items []labeledCount, errStr string, inn
 
 	rows := []string{head}
 	for _, it := range items {
-		label := th.TextStyle().Render(padRight(truncate(it.label, labelW), labelW))
+		label := th.TextStyle().
+			Render(padRight(truncate(it.label, labelW), labelW))
 		count := th.AccentStyle().Render(padLeft(formatCount(it.count), countW))
 		rows = append(rows, label+" "+count)
 	}
-	return panelBox(th).Width(inner).Render(lipgloss.JoinVertical(lipgloss.Left, rows...))
+	return panelBox(th).Width(inner).Render(strings.Join(rows, "\n"))
 }
 
 func padRight(s string, w int) string {

--- a/internal/tui/screens/dashboard/render_test.go
+++ b/internal/tui/screens/dashboard/render_test.go
@@ -40,7 +40,9 @@ func sampleHistory() pihole.History {
 }
 
 func sampleTypes() pihole.QueryTypes {
-	return pihole.QueryTypes{Types: map[string]int{"A": 10, "AAAA": 5, "PTR": 1}}
+	return pihole.QueryTypes{
+		Types: map[string]int{"A": 10, "AAAA": 5, "PTR": 1},
+	}
 }
 
 func sampleUpstreams() pihole.Upstreams {
@@ -52,13 +54,23 @@ func sampleUpstreams() pihole.Upstreams {
 
 func sampleTopDomains() pihole.TopDomains {
 	var td pihole.TopDomains
-	_ = json.Unmarshal([]byte(`{"domains":[{"domain":"example.com","count":42},{"domain":"news.example.org","count":17}]}`), &td)
+	_ = json.Unmarshal(
+		[]byte(
+			`{"domains":[{"domain":"example.com","count":42},{"domain":"news.example.org","count":17}]}`,
+		),
+		&td,
+	)
 	return td
 }
 
 func sampleTopClients() pihole.TopClients {
 	var tc pihole.TopClients
-	_ = json.Unmarshal([]byte(`{"clients":[{"ip":"10.0.0.1","name":"laptop","count":80},{"ip":"10.0.0.2","name":"","count":30}]}`), &tc)
+	_ = json.Unmarshal(
+		[]byte(
+			`{"clients":[{"ip":"10.0.0.1","name":"laptop","count":80},{"ip":"10.0.0.2","name":"","count":30}]}`,
+		),
+		&tc,
+	)
 	return tc
 }
 
@@ -198,7 +210,8 @@ func TestDomainItems_MapsDomainAndCount(t *testing.T) {
 	items := domainItems(sampleTopDomains())
 
 	// Assert
-	if len(items) != 2 || items[0].label != "example.com" || items[0].count != 42 {
+	if len(items) != 2 || items[0].label != "example.com" ||
+		items[0].count != 42 {
 		t.Fatalf("unexpected domain items: %+v", items)
 	}
 }

--- a/internal/tui/screens/dashboard/sparkline.go
+++ b/internal/tui/screens/dashboard/sparkline.go
@@ -48,7 +48,8 @@ func sparklineInt(values []int, width int) string {
 	return sparkline(fs, width)
 }
 
-// fraction returns v's position within [min, min+span] as a 0..1 value, guarding
+// fraction returns v's position within [min, min+span] as a 0..1 value,
+// guarding
 // against a zero span (flat series) by returning 0.
 func fraction(v, min, span float64) float64 {
 	if span <= 0 {

--- a/internal/tui/screens/domains/columns.go
+++ b/internal/tui/screens/domains/columns.go
@@ -31,9 +31,17 @@ const (
 )
 
 // columnTitles is the header row, in render order.
-var columnTitles = []string{"Type", "Kind", "Domain", "Comment", "Enabled", "Groups"}
+var columnTitles = []string{
+	"Type",
+	"Kind",
+	"Domain",
+	"Comment",
+	"Enabled",
+	"Groups",
+}
 
-// computeColumnWidths returns the content width of each column for a given total
+// computeColumnWidths returns the content width of each column for a given
+// total
 // width. Widths never sum past the available (padding-adjusted) space, and each
 // flexible column is clamped to a sane minimum so nothing collapses.
 func computeColumnWidths(total int) []int {
@@ -53,7 +61,14 @@ func computeColumnWidths(total int) []int {
 	domain = clampMin(domain, minFlexCol)
 	comment = clampMin(comment, minFlexCol)
 
-	return []int{colTypeWidth, colKindWidth, domain, comment, colEnabledWidth, colGroupsWidth}
+	return []int{
+		colTypeWidth,
+		colKindWidth,
+		domain,
+		comment,
+		colEnabledWidth,
+		colGroupsWidth,
+	}
 }
 
 func clampMin(v, min int) int {
@@ -85,7 +100,8 @@ func columnWidthsFrom(cols []table.Column) []int {
 	return w
 }
 
-// truncate shortens s to at most width display cells, appending an ellipsis when
+// truncate shortens s to at most width display cells, appending an ellipsis
+// when
 // it must cut. Rune-aware so multibyte domains are not split mid-rune.
 func truncate(s string, width int) string {
 	if width <= 0 {
@@ -153,7 +169,11 @@ func typeStyle(th *theme.Theme, dtype string) lipgloss.Style {
 // styledRows builds table rows from domains, colouring the Type cell by
 // allow/deny and the Enabled cell by state, using the current theme. Read at
 // View() time so live re-themes take effect immediately.
-func styledRows(th *theme.Theme, domains []pihole.Domain, widths []int) []table.Row {
+func styledRows(
+	th *theme.Theme,
+	domains []pihole.Domain,
+	widths []int,
+) []table.Row {
 	rows := make([]table.Row, len(domains))
 	for i, d := range domains {
 		cells := domainToRow(d, widths)

--- a/internal/tui/screens/domains/domains.go
+++ b/internal/tui/screens/domains/domains.go
@@ -1,13 +1,15 @@
 // Package domains implements the PiHole v6 Domains screen: allow/deny ×
-// exact/regex management. It presents a filterable table of managed domains with
-// inline add/edit forms, an enabled toggle, and a guarded delete. Data is loaded
-// on focus and on manual refresh (no continuous poll). It satisfies core.Screen.
+// exact/regex management. It presents a filterable table of managed domains
+// with inline add/edit forms, an enabled toggle, and a guarded delete. Data is
+// loaded on focus and on manual refresh (no continuous poll). It satisfies
+// core.Screen.
 package domains
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -39,7 +41,8 @@ type domainsMsg struct {
 	err     error
 }
 
-// mutationMsg carries the result of an add/update/delete, tagged with its epoch.
+// mutationMsg carries the result of an add/update/delete, tagged with its
+// epoch.
 // On success the screen refetches the full list.
 type mutationMsg struct {
 	epoch int
@@ -127,7 +130,10 @@ func (m *Model) Help() []key.Binding {
 		key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
 		key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit")),
 		key.NewBinding(key.WithKeys(" ", "t"), key.WithHelp("space", "toggle")),
-		key.NewBinding(key.WithKeys("x", "delete"), key.WithHelp("x", "delete")),
+		key.NewBinding(
+			key.WithKeys("x", "delete"),
+			key.WithHelp("x", "delete"),
+		),
 		key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "filter")),
 		key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
 	}
@@ -158,7 +164,8 @@ func (m *Model) SetSize(w, h int) {
 }
 
 // fetch issues a list request. The context+cancel are stored on the model
-// (Update runs on the main loop, so this mutation is safe); the closure performs
+// (Update runs on the main loop, so this mutation is safe); the closure
+// performs
 // the only I/O, off the Update path.
 func (m *Model) fetch() tea.Cmd {
 	if m.cancel != nil {
@@ -176,7 +183,8 @@ func (m *Model) fetch() tea.Cmd {
 	}
 }
 
-// mutate wraps a write operation in a timeout context and returns a command that
+// mutate wraps a write operation in a timeout context and returns a command
+// that
 // reports the outcome as a mutationMsg. Loading is set so the spinner shows.
 func (m *Model) mutate(op func(context.Context, *pihole.Client) error) tea.Cmd {
 	if m.cancel != nil {
@@ -266,7 +274,12 @@ func (m *Model) handleConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		target := *d
 		return m, m.mutate(func(ctx context.Context, api *pihole.Client) error {
-			return api.DeleteDomain(ctx, pihole.DomainType(target.Type), pihole.DomainKind(target.Kind), target.Domain)
+			return api.DeleteDomain(
+				ctx,
+				pihole.DomainType(target.Type),
+				pihole.DomainKind(target.Kind),
+				target.Domain,
+			)
 		})
 	case "n", "esc":
 		m.confirm = m.confirm.Hide()
@@ -331,7 +344,15 @@ func (m *Model) submitForm() (tea.Model, tea.Cmd) {
 
 	return m, m.mutate(func(ctx context.Context, api *pihole.Client) error {
 		if editing {
-			_, err := api.UpdateDomain(ctx, dtype, dkind, target, comment, groups, enabled)
+			_, err := api.UpdateDomain(
+				ctx,
+				dtype,
+				dkind,
+				target,
+				comment,
+				groups,
+				enabled,
+			)
 			return err
 		}
 		_, err := api.AddDomain(ctx, dtype, dkind, domain, comment, groups)
@@ -394,7 +415,15 @@ func (m *Model) toggleSelected() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, m.mutate(func(ctx context.Context, api *pihole.Client) error {
-		_, err := api.UpdateDomain(ctx, pihole.DomainType(d.Type), pihole.DomainKind(d.Kind), d.Domain, d.Comment, d.Groups, !d.Enabled)
+		_, err := api.UpdateDomain(
+			ctx,
+			pihole.DomainType(d.Type),
+			pihole.DomainKind(d.Kind),
+			d.Domain,
+			d.Comment,
+			d.Groups,
+			!d.Enabled,
+		)
 		return err
 	})
 }
@@ -419,6 +448,7 @@ func (m *Model) applyFilter() {
 func (m *Model) syncRows() {
 	widths := columnWidthsFrom(m.table.Columns())
 	idx := m.table.Cursor()
+	m.table.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.table.SetRows(styledRows(m.ctx.Theme, m.visible, widths))
 	if idx >= len(m.visible) {
 		idx = len(m.visible) - 1
@@ -442,7 +472,7 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
@@ -452,7 +482,8 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	for f := filterTab(0); f < filterCount; f++ {
 		labels = append(labels, f.label())
 	}
-	count := th.SubtleStyle().Render(fmt.Sprintf("%d shown · %d total", len(m.visible), len(m.domains)))
+	count := th.SubtleStyle().
+		Render(fmt.Sprintf("%d shown · %d total", len(m.visible), len(m.domains)))
 
 	line := components.SectionTabs{
 		Title:  m.Title(),
@@ -466,7 +497,7 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	if m.err != nil {
 		second = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, second)
+	return strings.Join([]string{line, second}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -488,13 +519,28 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	}
 
 	if m.loading && len(m.domains) == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading domains…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading domains…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if len(m.visible) == 0 {
 		empty := th.SubtleStyle().Render("no domains match this filter")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	return m.table.View()

--- a/internal/tui/screens/domains/domains_test.go
+++ b/internal/tui/screens/domains/domains_test.go
@@ -38,9 +38,27 @@ func keyPress(s string) tea.KeyPressMsg {
 
 func sampleDomains() []pihole.Domain {
 	return []pihole.Domain{
-		{Domain: "ads.example.com", Type: "deny", Kind: "exact", Enabled: true, ID: 1},
-		{Domain: "good.example.com", Type: "allow", Kind: "exact", Enabled: true, ID: 2},
-		{Domain: "(^|\\.)tracker\\.com$", Type: "deny", Kind: "regex", Enabled: false, ID: 3},
+		{
+			Domain:  "ads.example.com",
+			Type:    "deny",
+			Kind:    "exact",
+			Enabled: true,
+			ID:      1,
+		},
+		{
+			Domain:  "good.example.com",
+			Type:    "allow",
+			Kind:    "exact",
+			Enabled: true,
+			ID:      2,
+		},
+		{
+			Domain:  "(^|\\.)tracker\\.com$",
+			Type:    "deny",
+			Kind:    "regex",
+			Enabled: false,
+			ID:      3,
+		},
 	}
 }
 
@@ -83,7 +101,13 @@ func TestFilterDomainsSelectsMatchingTypeAndKind(t *testing.T) {
 func TestDomainToRowMapsFieldsInOrder(t *testing.T) {
 	// Arrange
 	widths := computeColumnWidths(120)
-	d := pihole.Domain{Domain: "ads.example.com", Type: "deny", Kind: "exact", Enabled: true, Groups: []int{0, 2}}
+	d := pihole.Domain{
+		Domain:  "ads.example.com",
+		Type:    "deny",
+		Kind:    "exact",
+		Enabled: true,
+		Groups:  []int{0, 2},
+	}
 
 	// Act
 	row := domainToRow(d, widths)
@@ -135,7 +159,11 @@ func TestFocusSetsLoadingAndBumpsEpoch(t *testing.T) {
 		t.Fatalf("focus should set loading")
 	}
 	if m.epoch != startEpoch+1 {
-		t.Fatalf("focus should bump epoch: got %d want %d", m.epoch, startEpoch+1)
+		t.Fatalf(
+			"focus should bump epoch: got %d want %d",
+			m.epoch,
+			startEpoch+1,
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("focus should return a fetch command")
@@ -158,7 +186,10 @@ func TestDomainsMsgPopulatesRowsAndClearsLoading(t *testing.T) {
 		t.Fatalf("expected 3 domains stored, got %d", len(m.domains))
 	}
 	if len(m.visible) != 3 {
-		t.Fatalf("default filter is all; expected 3 visible, got %d", len(m.visible))
+		t.Fatalf(
+			"default filter is all; expected 3 visible, got %d",
+			len(m.visible),
+		)
 	}
 }
 
@@ -309,7 +340,10 @@ func TestFilterKeyCyclesVisibleSet(t *testing.T) {
 	m := newTestModel()
 	_, _ = m.Update(domainsMsg{epoch: m.epoch, domains: sampleDomains()})
 	if len(m.visible) != 3 {
-		t.Fatalf("precondition: expected 3 visible under 'all', got %d", len(m.visible))
+		t.Fatalf(
+			"precondition: expected 3 visible under 'all', got %d",
+			len(m.visible),
+		)
 	}
 
 	// Act: all -> allow-exact
@@ -348,7 +382,10 @@ func TestMutationSuccessTriggersRefetch(t *testing.T) {
 
 	// Assert
 	if m.epoch != 5 {
-		t.Fatalf("successful mutation should bump epoch for refetch, got %d", m.epoch)
+		t.Fatalf(
+			"successful mutation should bump epoch for refetch, got %d",
+			m.epoch,
+		)
 	}
 	if !m.loading {
 		t.Fatalf("refetch should set loading")

--- a/internal/tui/screens/domains/domains_view_test.go
+++ b/internal/tui/screens/domains/domains_view_test.go
@@ -80,7 +80,8 @@ func TestDoubleFocusIsSafe(t *testing.T) {
 }
 
 func TestSetSizeNegativeAndReflowWithData(t *testing.T) {
-	// Arrange: populate + open a form so SetSize touches the form + rows branches.
+	// Arrange: populate + open a form so SetSize touches the form + rows
+	// branches.
 	m := newTestModel()
 	_, _ = m.Update(domainsMsg{epoch: m.epoch, domains: sampleDomains()})
 	_, _ = m.Update(keyPress("a"))
@@ -202,7 +203,13 @@ func TestFilterCyclesAllCombosAndRefiltersVisible(t *testing.T) {
 			t.Fatalf("step %d: filter=%v want %v", i, m.filter, w.tab)
 		}
 		if len(m.visible) != w.visible {
-			t.Fatalf("step %d (%v): visible=%d want %d", i, w.tab, len(m.visible), w.visible)
+			t.Fatalf(
+				"step %d (%v): visible=%d want %d",
+				i,
+				w.tab,
+				len(m.visible),
+				w.visible,
+			)
 		}
 	}
 }
@@ -328,13 +335,20 @@ func TestFormFieldCyclingForwardAndBack(t *testing.T) {
 		_, _ = m.Update(keyPress("tab"))
 	}
 	if m.form.focus != start {
-		t.Fatalf("cycling %d tabs should wrap to start, got %v", int(fieldCount), m.form.focus)
+		t.Fatalf(
+			"cycling %d tabs should wrap to start, got %v",
+			int(fieldCount),
+			m.form.focus,
+		)
 	}
 
 	// Act: shift+tab back one.
 	_, _ = m.Update(keyPress("shift+tab"))
 	if m.form.focus != fieldKind {
-		t.Fatalf("shift+tab from domain should step back to kind, got %v", m.form.focus)
+		t.Fatalf(
+			"shift+tab from domain should step back to kind, got %v",
+			m.form.focus,
+		)
 	}
 }
 
@@ -370,7 +384,10 @@ func TestFormTypingEditsFocusedInput(t *testing.T) {
 
 	// Assert
 	if !strings.Contains(m.form.comment.Value(), "z") {
-		t.Fatalf("typing should edit the focused input, got %q", m.form.comment.Value())
+		t.Fatalf(
+			"typing should edit the focused input, got %q",
+			m.form.comment.Value(),
+		)
 	}
 }
 
@@ -522,7 +539,12 @@ func TestTruncateBehaviour(t *testing.T) {
 
 func TestDomainToRowDefaultsAndDashComment(t *testing.T) {
 	// nil widths triggers the minFlex fallback path; blank comment -> "-".
-	d := pihole.Domain{Domain: "x.com", Type: "allow", Kind: "regex", Comment: "  "}
+	d := pihole.Domain{
+		Domain:  "x.com",
+		Type:    "allow",
+		Kind:    "regex",
+		Comment: "  ",
+	}
 	row := domainToRow(d, nil)
 	if row[3] != "-" {
 		t.Fatalf("blank comment should render as dash, got %q", row[3])
@@ -559,6 +581,10 @@ func TestFormTitleForBothModes(t *testing.T) {
 func TestNewAddFormSeedsFromConcreteTab(t *testing.T) {
 	f := newAddForm(filterAllowRegex)
 	if f.dtype != pihole.DomainAllow || f.dkind != pihole.KindRegex {
-		t.Fatalf("add form should seed type/kind from the tab, got %v/%v", f.dtype, f.dkind)
+		t.Fatalf(
+			"add form should seed type/kind from the tab, got %v/%v",
+			f.dtype,
+			f.dkind,
+		)
 	}
 }

--- a/internal/tui/screens/domains/filter.go
+++ b/internal/tui/screens/domains/filter.go
@@ -2,7 +2,8 @@ package domains
 
 import "github.com/zackkitzmiller/tihole/internal/pihole"
 
-// filterTab selects which subset of the fetched domains is shown. The tabs cycle
+// filterTab selects which subset of the fetched domains is shown. The tabs
+// cycle
 // through the four allow/deny × exact/regex combinations plus an "all" view.
 type filterTab int
 
@@ -42,7 +43,8 @@ func (f filterTab) prev() filterTab {
 	return (f + filterCount - 1) % filterCount
 }
 
-// typeKind resolves the tab's domain type and kind. Only meaningful for the four
+// typeKind resolves the tab's domain type and kind. Only meaningful for the
+// four
 // concrete tabs; filterAll is handled separately by filterDomains.
 func (f filterTab) typeKind() (pihole.DomainType, pihole.DomainKind) {
 	switch f {
@@ -59,7 +61,8 @@ func (f filterTab) typeKind() (pihole.DomainType, pihole.DomainKind) {
 	}
 }
 
-// filterDomains returns the subset of domains matching the given tab. The result
+// filterDomains returns the subset of domains matching the given tab. The
+// result
 // is a fresh slice, never a view onto the input.
 func filterDomains(domains []pihole.Domain, f filterTab) []pihole.Domain {
 	if f == filterAll {

--- a/internal/tui/screens/domains/form.go
+++ b/internal/tui/screens/domains/form.go
@@ -177,7 +177,8 @@ func (f *formState) render(th *theme.Theme, w, h int) string {
 		f.inputLine(th, fieldComment, "Comment", f.comment.View()),
 		f.inputLine(th, fieldGroups, "Groups", f.groups.View()),
 		"",
-		th.SubtleStyle().Render("tab next · ←/→ toggle · enter save · esc cancel"),
+		th.SubtleStyle().
+			Render("tab next · ←/→ toggle · enter save · esc cancel"),
 	}
 
 	panelW := w - 4
@@ -193,20 +194,44 @@ func (f *formState) render(th *theme.Theme, w, h int) string {
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(panelW).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		w,
+		h,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		th.SurfaceWhitespace(),
+	)
 }
 
-func (f *formState) toggleLine(th *theme.Theme, field formField, label, value string) string {
-	return f.fieldLabel(th, field, label) + "  " + th.TextStyle().Render("‹ "+value+" ›")
+func (f *formState) toggleLine(
+	th *theme.Theme,
+	field formField,
+	label, value string,
+) string {
+	return f.fieldLabel(
+		th,
+		field,
+		label,
+	) + "  " + th.TextStyle().
+		Render("‹ "+value+" ›")
 }
 
-func (f *formState) inputLine(th *theme.Theme, field formField, label, view string) string {
+func (f *formState) inputLine(
+	th *theme.Theme,
+	field formField,
+	label, view string,
+) string {
 	return f.fieldLabel(th, field, label) + "  " + view
 }
 
-func (f *formState) fieldLabel(th *theme.Theme, field formField, label string) string {
+func (f *formState) fieldLabel(
+	th *theme.Theme,
+	field formField,
+	label string,
+) string {
 	marker := "  "
 	style := th.SubtleStyle()
 	if f.focus == field {

--- a/internal/tui/screens/groups/columns.go
+++ b/internal/tui/screens/groups/columns.go
@@ -29,7 +29,8 @@ const (
 // columnTitles is the header row, in render order.
 var columnTitles = []string{"Name", "Comment", "Enabled", "ID"}
 
-// computeColumnWidths returns the content width of each column for a given total
+// computeColumnWidths returns the content width of each column for a given
+// total
 // width. Widths never sum past the available (padding-adjusted) space, and each
 // flexible column is clamped to a sane minimum so nothing collapses.
 func computeColumnWidths(total int) []int {
@@ -80,7 +81,8 @@ func columnWidthsFrom(cols []table.Column) []int {
 	return w
 }
 
-// truncate shortens s to at most width display cells, appending an ellipsis when
+// truncate shortens s to at most width display cells, appending an ellipsis
+// when
 // it must cut. Rune-aware so multibyte names are not split mid-rune.
 func truncate(s string, width int) string {
 	if width <= 0 {
@@ -122,7 +124,11 @@ func groupToRow(g pihole.Group, widths []int) []string {
 
 // styledRows builds table rows from groups, colouring the Enabled cell green
 // (allowed) or subtle (disabled) using the current theme. Read at View() time.
-func styledRows(th *theme.Theme, groups []pihole.Group, widths []int) []table.Row {
+func styledRows(
+	th *theme.Theme,
+	groups []pihole.Group,
+	widths []int,
+) []table.Row {
 	rows := make([]table.Row, len(groups))
 	for i, g := range groups {
 		cells := groupToRow(g, widths)

--- a/internal/tui/screens/groups/form.go
+++ b/internal/tui/screens/groups/form.go
@@ -65,7 +65,11 @@ func (f *groupForm) openAdd(width int) tea.Cmd {
 
 // openEdit pre-fills the form for editing an existing group. The name is kept
 // read-only; focus starts on the comment field.
-func (f *groupForm) openEdit(name, comment string, enabled bool, width int) tea.Cmd {
+func (f *groupForm) openEdit(
+	name, comment string,
+	enabled bool,
+	width int,
+) tea.Cmd {
 	f.active = true
 	f.editing = true
 	f.origName = name
@@ -114,7 +118,8 @@ func (f *groupForm) canSubmit() bool {
 	return strings.TrimSpace(f.name.Value()) != ""
 }
 
-// values returns the submitted name/comment/enabled and whether this is an edit.
+// values returns the submitted name/comment/enabled and whether this is an
+// edit.
 // For edits the original name is authoritative.
 func (f *groupForm) values() (name, comment string, enabled, editing bool) {
 	name = strings.TrimSpace(f.name.Value())
@@ -181,16 +186,35 @@ func (f *groupForm) view(th *theme.Theme, width int) string {
 	var lines []string
 	lines = append(lines, th.AccentStyle().Bold(true).Render(heading), "")
 
-	lines = append(lines, f.fieldRow(th, "Name", f.nameView(th), f.focused() == fieldName))
-	lines = append(lines, f.fieldRow(th, "Comment", f.comment.View(), f.focused() == fieldComment))
+	lines = append(
+		lines,
+		f.fieldRow(th, "Name", f.nameView(th), f.focused() == fieldName),
+	)
+	lines = append(
+		lines,
+		f.fieldRow(
+			th,
+			"Comment",
+			f.comment.View(),
+			f.focused() == fieldComment,
+		),
+	)
 
 	toggle := disabledGlyph + " disabled"
 	if f.enabled {
 		toggle = th.AllowStyle().Render(enabledGlyph + " enabled")
 	}
-	lines = append(lines, f.fieldRow(th, "Enabled", toggle, f.focused() == fieldEnabled))
+	lines = append(
+		lines,
+		f.fieldRow(th, "Enabled", toggle, f.focused() == fieldEnabled),
+	)
 
-	lines = append(lines, "", th.SubtleStyle().Render("tab move · space toggle · enter save · esc cancel"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().
+			Render("tab move · space toggle · enter save · esc cancel"),
+	)
 
 	panelW := maxInt(minInt(width-2, 60), 20)
 	return th.PanelStyle().
@@ -198,7 +222,7 @@ func (f *groupForm) view(th *theme.Theme, width int) string {
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(panelW).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 }
 
 // nameView renders the name field: the live input in add mode, or read-only
@@ -211,7 +235,11 @@ func (f *groupForm) nameView(th *theme.Theme) string {
 }
 
 // fieldRow renders a labelled field with a focus marker.
-func (f *groupForm) fieldRow(th *theme.Theme, label, value string, focused bool) string {
+func (f *groupForm) fieldRow(
+	th *theme.Theme,
+	label, value string,
+	focused bool,
+) string {
 	marker := "  "
 	if focused {
 		marker = th.AccentStyle().Render("▸ ")

--- a/internal/tui/screens/groups/groups.go
+++ b/internal/tui/screens/groups/groups.go
@@ -36,7 +36,8 @@ type groupsMsg struct {
 	err    error
 }
 
-// mutationMsg carries the result of an add/update/delete, tagged with its epoch.
+// mutationMsg carries the result of an add/update/delete, tagged with its
+// epoch.
 // On success the screen refetches the list.
 type mutationMsg struct {
 	epoch int
@@ -91,7 +92,8 @@ func (m *Model) Init() tea.Cmd { return nil }
 func (m *Model) Title() string { return "Groups" }
 
 // CapturesInput reports whether the add/edit form is focused, so the root
-// delivers raw keys instead of firing global shortcuts (see core.InputCapturer).
+// delivers raw keys instead of firing global shortcuts (see
+// core.InputCapturer).
 func (m *Model) CapturesInput() bool { return m.form.active }
 
 // Focus activates the screen: fetch a fresh list. No continuous poll.
@@ -144,7 +146,8 @@ func (m *Model) SetSize(w, h int) {
 }
 
 // fetch issues a fresh list request. The context+cancel are stored on the model
-// (Update runs on the main loop, so this mutation is safe); the closure performs
+// (Update runs on the main loop, so this mutation is safe); the closure
+// performs
 // the only I/O, off the Update path.
 func (m *Model) fetch() tea.Cmd {
 	ctx := m.newContext()
@@ -156,7 +159,8 @@ func (m *Model) fetch() tea.Cmd {
 	}
 }
 
-// newContext cancels any prior request and returns a fresh timeout context whose
+// newContext cancels any prior request and returns a fresh timeout context
+// whose
 // cancel is stored on the model.
 func (m *Model) newContext() context.Context {
 	if m.cancel != nil {
@@ -342,11 +346,13 @@ func (m *Model) handleListKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-// syncRows rebuilds the table rows from the current groups and theme, preserving
+// syncRows rebuilds the table rows from the current groups and theme,
+// preserving
 // the cursor position.
 func (m *Model) syncRows() {
 	widths := columnWidthsFrom(m.table.Columns())
 	idx := m.table.Cursor()
+	m.table.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.table.SetRows(styledRows(m.ctx.Theme, m.groups, widths))
 	m.table.SetCursor(idx)
 }
@@ -364,7 +370,7 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 
 	if m.confirm.Active {
@@ -382,7 +388,8 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 			enabled++
 		}
 	}
-	count := th.SubtleStyle().Render(fmt.Sprintf("%d groups · %d enabled", len(m.groups), enabled))
+	count := th.SubtleStyle().
+		Render(fmt.Sprintf("%d groups · %d enabled", len(m.groups), enabled))
 
 	gap := m.w - lipgloss.Width(title) - lipgloss.Width(count)
 	if gap < 1 {
@@ -394,7 +401,7 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	if m.err != nil {
 		sub = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, sub)
+	return strings.Join([]string{line, sub}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -409,17 +416,40 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	}
 
 	if m.form.active {
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Top, m.form.view(th, m.w))
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Top,
+			m.form.view(th, m.w),
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if m.loading && len(m.groups) == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading groups…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading groups…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if len(m.groups) == 0 {
-		empty := th.SubtleStyle().Render("no groups configured · press a to add")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		empty := th.SubtleStyle().
+			Render("no groups configured · press a to add")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	return m.table.View()

--- a/internal/tui/screens/groups/groups_test.go
+++ b/internal/tui/screens/groups/groups_test.go
@@ -344,7 +344,10 @@ func TestDeleteKeyOpensConfirm(t *testing.T) {
 		t.Fatalf("'x' should open the confirm dialog")
 	}
 	if m.pendingDelete != "kids" {
-		t.Fatalf("pending delete should be the selected group, got %q", m.pendingDelete)
+		t.Fatalf(
+			"pending delete should be the selected group, got %q",
+			m.pendingDelete,
+		)
 	}
 }
 
@@ -450,7 +453,9 @@ func TestSetSizeSafeAtTinySizes(t *testing.T) {
 func TestEditKeyOpensPrefilledForm(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.groups = []pihole.Group{{Name: "kids", Comment: "phones", Enabled: false, ID: 1}}
+	m.groups = []pihole.Group{
+		{Name: "kids", Comment: "phones", Enabled: false, ID: 1},
+	}
 	m.syncRows()
 
 	// Act
@@ -461,7 +466,10 @@ func TestEditKeyOpensPrefilledForm(t *testing.T) {
 		t.Fatalf("'e' should open the edit form in editing mode")
 	}
 	if m.form.origName != "kids" {
-		t.Fatalf("edit form should key on original name, got %q", m.form.origName)
+		t.Fatalf(
+			"edit form should key on original name, got %q",
+			m.form.origName,
+		)
 	}
 	if m.form.enabled {
 		t.Fatalf("edit form should carry the group's enabled state")

--- a/internal/tui/screens/groups/groups_view_test.go
+++ b/internal/tui/screens/groups/groups_view_test.go
@@ -36,7 +36,13 @@ func TestTruncateEdgeCases(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := truncate(tc.in, tc.width); got != tc.want {
-				t.Fatalf("truncate(%q,%d)=%q want %q", tc.in, tc.width, got, tc.want)
+				t.Fatalf(
+					"truncate(%q,%d)=%q want %q",
+					tc.in,
+					tc.width,
+					got,
+					tc.want,
+				)
 			}
 		})
 	}
@@ -123,13 +129,19 @@ func TestFormTabCyclesFocusAndTypes(t *testing.T) {
 	// Type a character into the focused comment field.
 	_, _ = m.Update(keyPress("z"))
 	if m.form.comment.Value() != "z" {
-		t.Fatalf("typing should append to focused field, got %q", m.form.comment.Value())
+		t.Fatalf(
+			"typing should append to focused field, got %q",
+			m.form.comment.Value(),
+		)
 	}
 
 	// Shift+tab wraps back to name.
 	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
 	if m.form.focused() != fieldName {
-		t.Fatalf("shift+tab should move focus back to name, got %d", m.form.focused())
+		t.Fatalf(
+			"shift+tab should move focus back to name, got %d",
+			m.form.focused(),
+		)
 	}
 }
 
@@ -153,7 +165,9 @@ func TestFormSpaceTogglesEnabledField(t *testing.T) {
 
 func TestEditFormSubmitReturnsUpdateCmd(t *testing.T) {
 	m := newViewModel()
-	m.groups = []pihole.Group{{Name: "kids", Comment: "phones", Enabled: true, ID: 1}}
+	m.groups = []pihole.Group{
+		{Name: "kids", Comment: "phones", Enabled: true, ID: 1},
+	}
 	m.syncRows()
 	_, _ = m.Update(keyPress("e"))
 	if !m.form.editing {
@@ -231,7 +245,11 @@ func TestDoubleFocusBumpsEpochEachTime(t *testing.T) {
 	first := m.epoch
 	_ = m.Focus()
 	if m.epoch != first+1 {
-		t.Fatalf("second Focus should bump epoch again: %d -> %d", first, m.epoch)
+		t.Fatalf(
+			"second Focus should bump epoch again: %d -> %d",
+			first,
+			m.epoch,
+		)
 	}
 }
 
@@ -370,7 +388,10 @@ func TestCommandClosuresReturnTaggedMessages(t *testing.T) {
 			t.Fatalf("fetch closure should emit a groupsMsg")
 		}
 		if msg.epoch != 7 || msg.err == nil {
-			t.Fatalf("cancelled fetch should carry epoch 7 and an error, got %+v", msg)
+			t.Fatalf(
+				"cancelled fetch should carry epoch 7 and an error, got %+v",
+				msg,
+			)
 		}
 	})
 
@@ -379,7 +400,10 @@ func TestCommandClosuresReturnTaggedMessages(t *testing.T) {
 		m.cancel()
 		msg, ok := cmd().(mutationMsg)
 		if !ok || msg.epoch != 7 || msg.err == nil {
-			t.Fatalf("cancelled add should emit an errored mutationMsg, got %+v", msg)
+			t.Fatalf(
+				"cancelled add should emit an errored mutationMsg, got %+v",
+				msg,
+			)
 		}
 	})
 
@@ -388,7 +412,10 @@ func TestCommandClosuresReturnTaggedMessages(t *testing.T) {
 		m.cancel()
 		msg, ok := cmd().(mutationMsg)
 		if !ok || msg.epoch != 7 || msg.err == nil {
-			t.Fatalf("cancelled update should emit an errored mutationMsg, got %+v", msg)
+			t.Fatalf(
+				"cancelled update should emit an errored mutationMsg, got %+v",
+				msg,
+			)
 		}
 	})
 
@@ -397,7 +424,10 @@ func TestCommandClosuresReturnTaggedMessages(t *testing.T) {
 		m.cancel()
 		msg, ok := cmd().(mutationMsg)
 		if !ok || msg.epoch != 7 || msg.err == nil {
-			t.Fatalf("cancelled delete should emit an errored mutationMsg, got %+v", msg)
+			t.Fatalf(
+				"cancelled delete should emit an errored mutationMsg, got %+v",
+				msg,
+			)
 		}
 	})
 }

--- a/internal/tui/screens/localdns/columns.go
+++ b/internal/tui/screens/localdns/columns.go
@@ -149,7 +149,11 @@ func cnameToRow(r pihole.CNAMERecord, widths []int) []string {
 
 // styledHostRows builds table rows from host records, colouring the IP cell in
 // the Accent token using the live theme.
-func styledHostRows(th *theme.Theme, records []pihole.HostRecord, widths []int) []table.Row {
+func styledHostRows(
+	th *theme.Theme,
+	records []pihole.HostRecord,
+	widths []int,
+) []table.Row {
 	rows := make([]table.Row, len(records))
 	for i, r := range records {
 		cells := hostToRow(r, widths)
@@ -161,7 +165,11 @@ func styledHostRows(th *theme.Theme, records []pihole.HostRecord, widths []int) 
 
 // styledCNAMERows builds table rows from CNAME records, colouring the Target
 // cell in the Accent token using the live theme.
-func styledCNAMERows(th *theme.Theme, records []pihole.CNAMERecord, widths []int) []table.Row {
+func styledCNAMERows(
+	th *theme.Theme,
+	records []pihole.CNAMERecord,
+	widths []int,
+) []table.Row {
 	rows := make([]table.Row, len(records))
 	for i, r := range records {
 		cells := cnameToRow(r, widths)

--- a/internal/tui/screens/localdns/form.go
+++ b/internal/tui/screens/localdns/form.go
@@ -134,7 +134,11 @@ func (f *formState) render(th *theme.Theme, w, h int) string {
 	for i, label := range f.labels {
 		lines = append(lines, f.inputLine(th, i, label, f.inputs[i].View()))
 	}
-	lines = append(lines, "", th.SubtleStyle().Render("tab next · enter save · esc cancel"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().Render("tab next · enter save · esc cancel"),
+	)
 
 	panelW := w - 4
 	if panelW < 24 {
@@ -149,12 +153,23 @@ func (f *formState) render(th *theme.Theme, w, h int) string {
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(panelW).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		w,
+		h,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		th.SurfaceWhitespace(),
+	)
 }
 
-func (f *formState) inputLine(th *theme.Theme, field int, label, view string) string {
+func (f *formState) inputLine(
+	th *theme.Theme,
+	field int,
+	label, view string,
+) string {
 	marker := "  "
 	style := th.SubtleStyle()
 	if f.focus == field {

--- a/internal/tui/screens/localdns/handlers.go
+++ b/internal/tui/screens/localdns/handlers.go
@@ -31,15 +31,19 @@ func (m *Model) handleConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.pendingCNAME = nil
 		if host != nil {
 			h := *host
-			return m, m.mutate(func(ctx context.Context, api *pihole.Client) error {
-				return api.DeleteHostRecord(ctx, h.IP, h.Domain)
-			})
+			return m, m.mutate(
+				func(ctx context.Context, api *pihole.Client) error {
+					return api.DeleteHostRecord(ctx, h.IP, h.Domain)
+				},
+			)
 		}
 		if cname != nil {
 			c := *cname
-			return m, m.mutate(func(ctx context.Context, api *pihole.Client) error {
-				return api.DeleteCNAMERecord(ctx, c.Domain, c.Target, c.TTL)
-			})
+			return m, m.mutate(
+				func(ctx context.Context, api *pihole.Client) error {
+					return api.DeleteCNAMERecord(ctx, c.Domain, c.Target, c.TTL)
+				},
+			)
 		}
 		return m, nil
 	case "n", "esc":
@@ -145,7 +149,11 @@ func (m *Model) requestDelete() (tea.Model, tea.Cmd) {
 		if idx >= 0 && idx < len(m.cnames) {
 			r := m.cnames[idx]
 			m.pendingCNAME = &r
-			m.confirm = m.confirm.Show("Delete CNAME record?", displayCNAME(r), true)
+			m.confirm = m.confirm.Show(
+				"Delete CNAME record?",
+				displayCNAME(r),
+				true,
+			)
 		}
 		return m, nil
 	}

--- a/internal/tui/screens/localdns/localdns.go
+++ b/internal/tui/screens/localdns/localdns.go
@@ -83,11 +83,15 @@ type Model struct {
 // New constructs the Local DNS screen from the shared app context.
 func New(ctx *core.AppContext) *Model {
 	ht := table.New(
-		table.WithColumns(tableColumns(hostColumnTitles, computeHostColumnWidths(80))),
+		table.WithColumns(
+			tableColumns(hostColumnTitles, computeHostColumnWidths(80)),
+		),
 		table.WithFocused(true),
 	)
 	ct := table.New(
-		table.WithColumns(tableColumns(cnameColumnTitles, computeCNAMEColumnWidths(80))),
+		table.WithColumns(
+			tableColumns(cnameColumnTitles, computeCNAMEColumnWidths(80)),
+		),
 		table.WithFocused(true),
 	)
 
@@ -138,7 +142,10 @@ func (m *Model) Blur() {
 func (m *Model) Help() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
-		key.NewBinding(key.WithKeys("x", "delete"), key.WithHelp("x", "delete")),
+		key.NewBinding(
+			key.WithKeys("x", "delete"),
+			key.WithHelp("x", "delete"),
+		),
 		key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "switch kind")),
 		key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
 	}
@@ -148,9 +155,13 @@ func (m *Model) Help() []key.Binding {
 func (m *Model) SetSize(w, h int) {
 	m.w, m.h = w, h
 
-	m.hostTable.SetColumns(tableColumns(hostColumnTitles, computeHostColumnWidths(w)))
+	m.hostTable.SetColumns(
+		tableColumns(hostColumnTitles, computeHostColumnWidths(w)),
+	)
 	m.hostTable.SetWidth(w)
-	m.cnameTable.SetColumns(tableColumns(cnameColumnTitles, computeCNAMEColumnWidths(w)))
+	m.cnameTable.SetColumns(
+		tableColumns(cnameColumnTitles, computeCNAMEColumnWidths(w)),
+	)
 	m.cnameTable.SetWidth(w)
 
 	tableH := h - headerHeight - footerHeight
@@ -282,6 +293,7 @@ func (m *Model) syncRows() {
 func (m *Model) syncHostRows() {
 	widths := columnWidthsFrom(m.hostTable.Columns())
 	idx := m.hostTable.Cursor()
+	m.hostTable.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.hostTable.SetRows(styledHostRows(m.ctx.Theme, m.hosts, widths))
 	m.hostTable.SetCursor(clampCursor(idx, len(m.hosts)))
 }
@@ -290,6 +302,7 @@ func (m *Model) syncHostRows() {
 func (m *Model) syncCNAMERows() {
 	widths := columnWidthsFrom(m.cnameTable.Columns())
 	idx := m.cnameTable.Cursor()
+	m.cnameTable.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.cnameTable.SetRows(styledCNAMERows(m.ctx.Theme, m.cnames, widths))
 	m.cnameTable.SetCursor(clampCursor(idx, len(m.cnames)))
 }

--- a/internal/tui/screens/localdns/localdns_test.go
+++ b/internal/tui/screens/localdns/localdns_test.go
@@ -92,8 +92,14 @@ func TestCNAMEToRowBlanksZeroTTL(t *testing.T) {
 	widths := computeCNAMEColumnWidths(120)
 
 	// Act
-	zero := cnameToRow(pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan", TTL: 0}, widths)
-	set := cnameToRow(pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan", TTL: 300}, widths)
+	zero := cnameToRow(
+		pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan", TTL: 0},
+		widths,
+	)
+	set := cnameToRow(
+		pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan", TTL: 300},
+		widths,
+	)
 
 	// Assert
 	if zero[2] != "" {
@@ -133,7 +139,11 @@ func TestFocusSetsLoadingAndBumpsEpoch(t *testing.T) {
 		t.Fatalf("focus should set loading")
 	}
 	if m.epoch != startEpoch+1 {
-		t.Fatalf("focus should bump epoch: got %d want %d", m.epoch, startEpoch+1)
+		t.Fatalf(
+			"focus should bump epoch: got %d want %d",
+			m.epoch,
+			startEpoch+1,
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("focus should return a fetch command")
@@ -245,7 +255,10 @@ func TestAddKeyOpensFormWithKindFields(t *testing.T) {
 		t.Fatalf("'a' should open the add form")
 	}
 	if len(m.form.inputs) != 2 {
-		t.Fatalf("host add form should have 2 fields, got %d", len(m.form.inputs))
+		t.Fatalf(
+			"host add form should have 2 fields, got %d",
+			len(m.form.inputs),
+		)
 	}
 
 	// Act: switch to cnames, open form
@@ -258,7 +271,10 @@ func TestAddKeyOpensFormWithKindFields(t *testing.T) {
 		t.Fatalf("cname add form should open in cname kind")
 	}
 	if len(m.form.inputs) != 3 {
-		t.Fatalf("cname add form should have 3 fields, got %d", len(m.form.inputs))
+		t.Fatalf(
+			"cname add form should have 3 fields, got %d",
+			len(m.form.inputs),
+		)
 	}
 }
 
@@ -277,7 +293,9 @@ func TestSubmitHostFormReturnsCmdAndClosesForm(t *testing.T) {
 		t.Fatalf("submitting should close the form")
 	}
 	if cmd == nil {
-		t.Fatalf("submitting a valid host form should return a mutation command")
+		t.Fatalf(
+			"submitting a valid host form should return a mutation command",
+		)
 	}
 }
 
@@ -298,7 +316,9 @@ func TestSubmitCNAMEFormReturnsCmdAndClosesForm(t *testing.T) {
 		t.Fatalf("submitting should close the form")
 	}
 	if cmd == nil {
-		t.Fatalf("submitting a valid cname form should return a mutation command")
+		t.Fatalf(
+			"submitting a valid cname form should return a mutation command",
+		)
 	}
 }
 
@@ -410,7 +430,10 @@ func TestMutationSuccessTriggersRefetch(t *testing.T) {
 
 	// Assert
 	if m.epoch != 5 {
-		t.Fatalf("successful mutation should bump epoch for refetch, got %d", m.epoch)
+		t.Fatalf(
+			"successful mutation should bump epoch for refetch, got %d",
+			m.epoch,
+		)
 	}
 	if !m.loading {
 		t.Fatalf("refetch should set loading")

--- a/internal/tui/screens/localdns/localdns_view_test.go
+++ b/internal/tui/screens/localdns/localdns_view_test.go
@@ -117,7 +117,10 @@ func TestRecordKindPrevAndLabelFallback(t *testing.T) {
 		t.Fatalf("prev of cnames should be hosts")
 	}
 	if kindCount.label() != "Hosts (A/AAAA)" {
-		t.Fatalf("unknown kind should fall back to hosts label, got %q", kindCount.label())
+		t.Fatalf(
+			"unknown kind should fall back to hosts label, got %q",
+			kindCount.label(),
+		)
 	}
 }
 
@@ -181,7 +184,8 @@ func TestViewErrorBannerAtTinyWidth(t *testing.T) {
 
 func TestViewErrorBannerDoesNotOverflowSurface(t *testing.T) {
 	// At a short height with an error banner present, the rendered surface must
-	// stay exactly m.h tall: body height is derived from the real header/footer.
+	// stay exactly m.h tall: body height is derived from the real
+	// header/footer.
 	const h = 8
 	m := newTestModel()
 	m.SetSize(40, h)
@@ -251,7 +255,10 @@ func TestFormNavigationAndTyping(t *testing.T) {
 	// typing routes to the focused input.
 	_, _ = m.Update(keyPress("z"))
 	if !strings.Contains(m.form.inputs[1].Value(), "z") {
-		t.Fatalf("typing should edit the focused input, got %q", m.form.inputs[1].Value())
+		t.Fatalf(
+			"typing should edit the focused input, got %q",
+			m.form.inputs[1].Value(),
+		)
 	}
 
 	// esc closes the form.
@@ -275,7 +282,12 @@ func TestRefreshKeyBumpsEpochAndLoads(t *testing.T) {
 	before := m.epoch
 	_, cmd := m.Update(keyPress("r"))
 	if m.epoch != before+1 || !m.loading || cmd == nil {
-		t.Fatalf("r should refetch: epoch=%d loading=%v cmd=%v", m.epoch, m.loading, cmd)
+		t.Fatalf(
+			"r should refetch: epoch=%d loading=%v cmd=%v",
+			m.epoch,
+			m.loading,
+			cmd,
+		)
 	}
 }
 
@@ -438,11 +450,15 @@ func TestTruncateEdgeCases(t *testing.T) {
 }
 
 func TestDisplayCNAMEIncludesTTLWhenPositive(t *testing.T) {
-	with := displayCNAME(pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan", TTL: 300})
+	with := displayCNAME(
+		pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan", TTL: 300},
+	)
 	if !strings.Contains(with, "ttl 300") {
 		t.Fatalf("positive ttl should appear, got %q", with)
 	}
-	without := displayCNAME(pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan"})
+	without := displayCNAME(
+		pihole.CNAMERecord{Domain: "a.lan", Target: "b.lan"},
+	)
 	if strings.Contains(without, "ttl") {
 		t.Fatalf("zero ttl should be omitted, got %q", without)
 	}

--- a/internal/tui/screens/localdns/view.go
+++ b/internal/tui/screens/localdns/view.go
@@ -2,6 +2,7 @@ package localdns
 
 import (
 	"fmt"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -27,7 +28,7 @@ func (m *Model) View() tea.View {
 	}
 	body := m.renderBody(th, bodyH)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
@@ -51,7 +52,7 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	if m.err != nil {
 		second = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, second)
+	return strings.Join([]string{line, second}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -68,13 +69,28 @@ func (m *Model) renderBody(th *theme.Theme, bodyH int) string {
 	}
 
 	if m.loading && m.activeCount() == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading records…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading records…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if m.activeCount() == 0 {
 		empty := th.SubtleStyle().Render("no " + m.kind.label() + " records")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if m.kind == kindCNAMEs {

--- a/internal/tui/screens/placeholder/placeholder.go
+++ b/internal/tui/screens/placeholder/placeholder.go
@@ -6,6 +6,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"strings"
 
 	"github.com/zackkitzmiller/tihole/internal/tui/core"
 )
@@ -34,8 +35,15 @@ func (m *Model) View() tea.View {
 	th := m.ctx.Theme
 	heading := th.AccentStyle().Bold(true).Render(m.title)
 	sub := th.SubtleStyle().Render("This screen isn't built yet — coming soon.")
-	body := lipgloss.JoinVertical(lipgloss.Center, heading, "", sub)
+	body := strings.Join([]string{heading, "", sub}, "\n")
 
-	content := lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, body)
+	content := lipgloss.Place(
+		m.w,
+		m.h,
+		lipgloss.Center,
+		lipgloss.Center,
+		body,
+		th.SurfaceWhitespace(),
+	)
 	return tea.NewView(th.SurfaceStyle().Width(m.w).Height(m.h).Render(content))
 }

--- a/internal/tui/screens/querylog/columns.go
+++ b/internal/tui/screens/querylog/columns.go
@@ -32,7 +32,14 @@ const (
 )
 
 // columnTitles is the header row, in render order.
-var columnTitles = []string{"Time", "Domain", "Client", "Type", "Status", "Upstream"}
+var columnTitles = []string{
+	"Time",
+	"Domain",
+	"Client",
+	"Type",
+	"Status",
+	"Upstream",
+}
 
 // computeColumnWidths returns the content width of each column for a given
 // total width. Widths never sum past the available (padding-adjusted) space,
@@ -56,7 +63,14 @@ func computeColumnWidths(total int) []int {
 	client = clampMin(client, minFlexCol)
 	upstream = clampMin(upstream, minFlexCol)
 
-	return []int{colTimeWidth, domain, client, colTypeWidth, colStatusWidth, upstream}
+	return []int{
+		colTimeWidth,
+		domain,
+		client,
+		colTypeWidth,
+		colStatusWidth,
+		upstream,
+	}
 }
 
 func clampMin(v, min int) int {
@@ -157,7 +171,8 @@ func statusToken(status string) string {
 	}
 }
 
-// styleForToken resolves a style token to a lipgloss style using the live theme.
+// styleForToken resolves a style token to a lipgloss style using the live
+// theme.
 func styleForToken(th *theme.Theme, token string) lipgloss.Style {
 	switch token {
 	case tokenBlock:
@@ -171,7 +186,11 @@ func styleForToken(th *theme.Theme, token string) lipgloss.Style {
 
 // styledRows builds table rows from queries, colouring the Domain and Status
 // cells by the row's status token using the current theme. Read at View() time.
-func styledRows(th *theme.Theme, queries []pihole.Query, widths []int) []table.Row {
+func styledRows(
+	th *theme.Theme,
+	queries []pihole.Query,
+	widths []int,
+) []table.Row {
 	rows := make([]table.Row, len(queries))
 	for i, q := range queries {
 		cells := queryToRow(q, widths)
@@ -184,7 +203,8 @@ func styledRows(th *theme.Theme, queries []pihole.Query, widths []int) []table.R
 }
 
 // buildFilter constructs a QueryFilter for a fresh page: an optional domain
-// search plus the page length. Only set (non-nil) fields are sent by the client.
+// search plus the page length. Only set (non-nil) fields are sent by the
+// client.
 func buildFilter(domain string, length int, cursor *int64) pihole.QueryFilter {
 	f := pihole.QueryFilter{}
 	if length > 0 {

--- a/internal/tui/screens/querylog/querylog.go
+++ b/internal/tui/screens/querylog/querylog.go
@@ -1,4 +1,5 @@
-// Package querylog implements the PiHole v6 query-log screen: a cursor-paginated
+// Package querylog implements the PiHole v6 query-log screen: a
+// cursor-paginated
 // results table with /-triggered domain search, a row-detail pane, live ~2s
 // polling while focused, and an inline error banner. It satisfies core.Screen.
 package querylog
@@ -388,7 +389,14 @@ func (m *Model) classify(dt pihole.DomainType, domain string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 		defer cancel()
-		_, err := api.AddDomain(ctx, dt, pihole.KindExact, domain, classifyComment, nil)
+		_, err := api.AddDomain(
+			ctx,
+			dt,
+			pihole.KindExact,
+			domain,
+			classifyComment,
+			nil,
+		)
 		return classifyMsg{domain: domain, verb: verb, err: err}
 	}
 }
@@ -398,6 +406,7 @@ func (m *Model) classify(dt pihole.DomainType, domain string) tea.Cmd {
 func (m *Model) syncRows() {
 	widths := columnWidthsFrom(m.table.Columns())
 	idx := m.table.Cursor()
+	m.table.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.table.SetRows(styledRows(m.ctx.Theme, m.queries, widths))
 	m.table.SetCursor(idx)
 }
@@ -425,7 +434,7 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
@@ -443,7 +452,8 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 		Padding(0, 1).
 		Render(chipLabel)
 
-	count := th.SubtleStyle().Render(fmt.Sprintf("%d shown · %d total", m.filtered, m.total))
+	count := th.SubtleStyle().
+		Render(fmt.Sprintf("%d shown · %d total", m.filtered, m.total))
 
 	left := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", chip)
 	gap := m.w - lipgloss.Width(left) - lipgloss.Width(count)
@@ -459,9 +469,11 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	case m.err != nil:
 		searchLine = m.errBanner(th)
 	case m.note != "":
-		searchLine = th.AllowStyle().Bold(true).Render(truncate("✓ "+m.note, maxInt(m.w-2, 8)))
+		searchLine = th.AllowStyle().
+			Bold(true).
+			Render(truncate("✓ "+m.note, maxInt(m.w-2, 8)))
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, searchLine)
+	return strings.Join([]string{line, searchLine}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -484,13 +496,28 @@ func (m *Model) renderBody(th *theme.Theme) string {
 	}
 
 	if m.loading && len(m.queries) == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading queries…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading queries…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	if len(m.queries) == 0 {
 		empty := th.SubtleStyle().Render("no queries match this filter")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	return m.table.View()
@@ -505,7 +532,10 @@ func (m *Model) renderDetail(th *theme.Theme, bodyH int) string {
 		{"Client", clientDetail(q.Client)},
 		{"Type", q.Type},
 		{"Status", q.Status},
-		{"Reply", fmt.Sprintf("%s (%.1fms)", orDash(q.Reply.Type), q.Reply.Time*1000)},
+		{
+			"Reply",
+			fmt.Sprintf("%s (%.1fms)", orDash(q.Reply.Type), q.Reply.Time*1000),
+		},
 		{"Upstream", orDash(q.Upstream)},
 		{"DNSSEC", orDash(q.DNSSEC)},
 		{"Time", formatQueryTime(q.Time)},
@@ -531,9 +561,16 @@ func (m *Model) renderDetail(th *theme.Theme, bodyH int) string {
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(maxInt(minInt(m.w-2, 60), 20)).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		m.w,
+		bodyH,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		th.SurfaceWhitespace(),
+	)
 }
 
 func (m *Model) renderFooter(th *theme.Theme) string {

--- a/internal/tui/screens/querylog/querylog_test.go
+++ b/internal/tui/screens/querylog/querylog_test.go
@@ -258,7 +258,9 @@ func TestUpdateIgnoresStaleQueriesResult(t *testing.T) {
 	m.loading = true
 
 	// Act
-	_, _ = m.Update(queriesMsg{epoch: 8, page: pihole.QueriesPage{RecordsTotal: 100}})
+	_, _ = m.Update(
+		queriesMsg{epoch: 8, page: pihole.QueriesPage{RecordsTotal: 100}},
+	)
 
 	// Assert
 	if m.total == 100 {

--- a/internal/tui/screens/querylog/querylog_view_test.go
+++ b/internal/tui/screens/querylog/querylog_view_test.go
@@ -151,7 +151,11 @@ func TestQueriesMsgPopulatesStateAndClearsLoading(t *testing.T) {
 		t.Fatalf("queriesMsg should store queries, got %d", len(m.queries))
 	}
 	if m.filtered != 2 || m.total != 500 {
-		t.Fatalf("queriesMsg should carry counts: filtered=%d total=%d", m.filtered, m.total)
+		t.Fatalf(
+			"queriesMsg should carry counts: filtered=%d total=%d",
+			m.filtered,
+			m.total,
+		)
 	}
 	if m.err != nil {
 		t.Fatalf("a successful result should clear the error")
@@ -223,7 +227,10 @@ func TestSlashOpensSearchSeededWithFilter(t *testing.T) {
 		t.Fatalf("'/' should enter search mode")
 	}
 	if m.search.Value() != "seed.example.com" {
-		t.Fatalf("search box should seed with the active filter, got %q", m.search.Value())
+		t.Fatalf(
+			"search box should seed with the active filter, got %q",
+			m.search.Value(),
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("'/' should return the input focus command")
@@ -276,7 +283,10 @@ func TestSearchEscRestoresPriorFilter(t *testing.T) {
 		t.Fatalf("esc should not change the applied filter")
 	}
 	if m.search.Value() != "keep.example.com" {
-		t.Fatalf("esc should reset the box to the applied filter, got %q", m.search.Value())
+		t.Fatalf(
+			"esc should reset the box to the applied filter, got %q",
+			m.search.Value(),
+		)
 	}
 	if cmd != nil {
 		t.Fatalf("esc out of search should not issue a command")
@@ -293,14 +303,22 @@ func TestSearchTypingEditsBox(t *testing.T) {
 
 	// Assert
 	if !strings.Contains(m.search.Value(), "x") {
-		t.Fatalf("typing in search mode should edit the box, got %q", m.search.Value())
+		t.Fatalf(
+			"typing in search mode should edit the box, got %q",
+			m.search.Value(),
+		)
 	}
 }
 
 func TestEnterOpensDetailForCursorRow(t *testing.T) {
 	// Arrange
 	m := newModel()
-	_, _ = m.Update(queriesMsg{epoch: m.epoch, page: pihole.QueriesPage{Queries: sampleQueries()}})
+	_, _ = m.Update(
+		queriesMsg{
+			epoch: m.epoch,
+			page:  pihole.QueriesPage{Queries: sampleQueries()},
+		},
+	)
 
 	// Act
 	_, _ = m.Update(keyPress("enter"))
@@ -332,7 +350,12 @@ func TestDetailEscCloses(t *testing.T) {
 func TestNavigationKeyPassesToTableWithoutPanic(t *testing.T) {
 	// Arrange
 	m := newModel()
-	_, _ = m.Update(queriesMsg{epoch: m.epoch, page: pihole.QueriesPage{Queries: sampleQueries()}})
+	_, _ = m.Update(
+		queriesMsg{
+			epoch: m.epoch,
+			page:  pihole.QueriesPage{Queries: sampleQueries()},
+		},
+	)
 
 	// Act / Assert (no panic, routes to table)
 	_, _ = m.Update(keyPress("j"))
@@ -367,7 +390,12 @@ func TestViewShowsFilterChipWhenFiltering(t *testing.T) {
 	// Arrange
 	m := newModel()
 	m.filterDomain = "ads.example.com"
-	_, _ = m.Update(queriesMsg{epoch: m.epoch, page: pihole.QueriesPage{Queries: sampleQueries()}})
+	_, _ = m.Update(
+		queriesMsg{
+			epoch: m.epoch,
+			page:  pihole.QueriesPage{Queries: sampleQueries()},
+		},
+	)
 
 	// Act
 	out := m.View().Content
@@ -511,8 +539,15 @@ func TestMaxMinInt(t *testing.T) {
 func TestStyleForTokenRendersText(t *testing.T) {
 	th := theme.DeepNight()
 	for _, tok := range []string{tokenBlock, tokenAllow, tokenNeutral, "unknown"} {
-		if out := styleForToken(th, tok).Render("cell"); !strings.Contains(out, "cell") {
-			t.Fatalf("styleForToken(%q) should render its text, got %q", tok, out)
+		if out := styleForToken(th, tok).Render("cell"); !strings.Contains(
+			out,
+			"cell",
+		) {
+			t.Fatalf(
+				"styleForToken(%q) should render its text, got %q",
+				tok,
+				out,
+			)
 		}
 	}
 }
@@ -551,7 +586,12 @@ func TestColumnWidthsFromRoundTrips(t *testing.T) {
 	}
 	for i := range widths {
 		if got[i] != widths[i] {
-			t.Fatalf("column %d width mismatch: got %d want %d", i, got[i], widths[i])
+			t.Fatalf(
+				"column %d width mismatch: got %d want %d",
+				i,
+				got[i],
+				widths[i],
+			)
 		}
 	}
 }

--- a/internal/tui/screens/querylog/quickclassify_test.go
+++ b/internal/tui/screens/querylog/quickclassify_test.go
@@ -84,7 +84,9 @@ func TestQuickActionSuppressedWhileSearching(t *testing.T) {
 
 	// Assert
 	if m.confirm.Active {
-		t.Fatalf("quick-classify must not trigger while the search field is focused")
+		t.Fatalf(
+			"quick-classify must not trigger while the search field is focused",
+		)
 	}
 }
 
@@ -101,7 +103,10 @@ func TestConfirmCancelHidesDialog(t *testing.T) {
 		t.Fatalf("n should dismiss the confirm dialog")
 	}
 	if m.pendingDomain != "" {
-		t.Fatalf("cancel should clear the pending domain, got %q", m.pendingDomain)
+		t.Fatalf(
+			"cancel should clear the pending domain, got %q",
+			m.pendingDomain,
+		)
 	}
 }
 
@@ -130,7 +135,9 @@ func TestCapturesInputDuringConfirm(t *testing.T) {
 	// Assert: while the confirm is up the screen must own y/n/esc so global
 	// shortcuts (d=toggle-block) and the esc-to-rail climb don't steal them.
 	if !m.CapturesInput() {
-		t.Fatalf("screen should capture input while the confirm dialog is active")
+		t.Fatalf(
+			"screen should capture input while the confirm dialog is active",
+		)
 	}
 }
 
@@ -166,7 +173,9 @@ func TestClassifyErrorSurfacesBanner(t *testing.T) {
 	m := modelWithQuery("ads.example.com")
 
 	// Act
-	_, _ = m.Update(classifyMsg{domain: "ads.example.com", verb: "blocked", err: errTest})
+	_, _ = m.Update(
+		classifyMsg{domain: "ads.example.com", verb: "blocked", err: errTest},
+	)
 
 	// Assert
 	if m.err == nil {
@@ -188,7 +197,10 @@ func TestClassifyWorksFromDetailPane(t *testing.T) {
 
 	// Assert: the confirm targets the detail domain, not the table cursor
 	if m.confirm.Message != "detail.example.com" {
-		t.Fatalf("classify from detail should target the detail domain, got %q", m.confirm.Message)
+		t.Fatalf(
+			"classify from detail should target the detail domain, got %q",
+			m.confirm.Message,
+		)
 	}
 }
 

--- a/internal/tui/screens/settings/connections.go
+++ b/internal/tui/screens/settings/connections.go
@@ -1,12 +1,16 @@
 package settings
 
 import (
+	"image/color"
+	"strings"
+
 	"charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/zackkitzmiller/tihole/internal/config"
 	"github.com/zackkitzmiller/tihole/internal/theme"
+	"github.com/zackkitzmiller/tihole/internal/tui/components"
 )
 
 const (
@@ -16,7 +20,8 @@ const (
 // connColumnTitles is the header row for the instances table.
 var connColumnTitles = []string{"Name", "URL", "Auth", "TLS", "Active"}
 
-// authLabel describes an instance's credential source without ever revealing the
+// authLabel describes an instance's credential source without ever revealing
+// the
 // secret: "inline" when a password is stored, "env:NAME" when sourced from the
 // environment, and "—" when neither is configured.
 func authLabel(inst config.Instance) string {
@@ -79,7 +84,9 @@ func connRows(th *theme.Theme, c *config.Config, widths []int) []table.Row {
 		}
 		active := ""
 		if inst.Name == c.Active {
-			active = lipgloss.NewStyle().Foreground(th.Allow).Render(glyphActive)
+			active = lipgloss.NewStyle().
+				Foreground(th.Allow).
+				Render(glyphActive)
 		}
 		rows[i] = table.Row{
 			truncate(inst.Name, nameW),
@@ -157,7 +164,44 @@ func (p *themePicker) render(th *theme.Theme, w, h int, current string) string {
 	return p.renderPanel(th, w, h, current)
 }
 
-func (p *themePicker) renderPanel(th *theme.Theme, width, height int, current string) string {
+// themeBlurb is a one-line description of each built-in theme, shown for the
+// highlighted entry so the picker sells the look before you commit to it.
+func themeBlurb(name string) string {
+	switch name {
+	case theme.NameAuto:
+		return "Follows your terminal — Gloss on dark, Light Luxury on light."
+	case theme.NameGloss:
+		return "Signature hot-pink-to-cyan lipgloss palette on deep void."
+	case theme.NameDeepNight:
+		return "Calm midnight navy with a soft periwinkle accent."
+	case theme.NameLightLuxury:
+		return "Warm ivory paper with a disciplined brass accent."
+	case theme.NamePiholeClassic:
+		return "The familiar Pi-hole red on warm near-black."
+	default:
+		return ""
+	}
+}
+
+// themeSwatch renders four filled cells in a theme's signature tokens so the
+// picker previews the palette without applying it.
+func themeSwatch(name string) string {
+	t, ok := theme.Builtin(name)
+	if !ok {
+		return ""
+	}
+	const block = "██"
+	cell := func(c color.Color) string {
+		return lipgloss.NewStyle().Foreground(c).Render(block)
+	}
+	return cell(t.Accent) + cell(t.Allow) + cell(t.Warn) + cell(t.Block)
+}
+
+func (p *themePicker) renderPanel(
+	th *theme.Theme,
+	width, height int,
+	current string,
+) string {
 	heading := th.AccentStyle().Bold(true).Render("Select theme")
 	lines := []string{heading, ""}
 	for i, n := range p.names {
@@ -165,24 +209,37 @@ func (p *themePicker) renderPanel(th *theme.Theme, width, height int, current st
 		style := th.TextStyle()
 		if i == p.cursor {
 			marker = "▸ "
-			style = th.AccentStyle()
+			style = th.AccentStyle().Bold(true)
 		}
-		row := marker + style.Render(n)
+		row := marker + themeSwatch(n) + " " + style.Render(n)
 		if n == current {
 			row += " " + th.SubtleStyle().Render("(current)")
 		}
 		lines = append(lines, row)
 	}
-	lines = append(lines, "", th.SubtleStyle().Render("↑↓ move · enter select · esc cancel"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().Render(themeBlurb(p.selected())),
+		"",
+		th.SubtleStyle().Render("↑↓ move · enter select · esc cancel"),
+	)
 
-	panelW := clampInt(width-4, 24, 48)
+	panelW := clampInt(width-4, 32, 60)
 	panel := th.PanelStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(panelW).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
-	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Top, panel)
+		Render(strings.Join(lines, "\n"))
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		surfaceWhitespace(th),
+	)
 }
 
 // --- Model methods for Connections mode ---
@@ -193,6 +250,7 @@ func (m *Model) rebuildConnRows() {
 	m.connTable.SetColumns(connColumns(widths))
 	m.connTable.SetWidth(m.w)
 	idx := m.connTable.Cursor()
+	m.connTable.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.connTable.SetRows(connRows(m.ctx.Theme, m.ctx.Config, widths))
 	if n := m.instanceCount(); idx >= n {
 		idx = n - 1
@@ -413,7 +471,8 @@ func (m *Model) selectTheme() (tea.Model, tea.Cmd) {
 	return m, emitSetTheme(resolved)
 }
 
-// renderConnBody renders the Connections mode body: the form, confirm dialog, or
+// renderConnBody renders the Connections mode body: the form, confirm dialog,
+// or
 // theme picker overlay when active, otherwise the instances table plus a theme
 // summary line.
 func (m *Model) renderConnBody(th *theme.Theme, bodyH int) string {
@@ -433,12 +492,19 @@ func (m *Model) renderConnBody(th *theme.Theme, bodyH int) string {
 
 	if m.instanceCount() == 0 {
 		empty := th.SubtleStyle().Render("no instances configured")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			surfaceWhitespace(th),
+		)
 	}
 
 	table := m.connTable.View()
 	summary := m.renderThemeSummary(th)
-	return lipgloss.JoinVertical(lipgloss.Left, table, "", summary)
+	return strings.Join([]string{table, "", summary}, "\n")
 }
 
 // renderThemeSummary shows the available themes with the active one marked.

--- a/internal/tui/screens/settings/form.go
+++ b/internal/tui/screens/settings/form.go
@@ -94,6 +94,7 @@ func (f *instanceForm) title() string {
 }
 
 func (f *instanceForm) focusNext() { f.focus = (f.focus + 1) % instFieldCount }
+
 func (f *instanceForm) focusPrev() { f.focus = (f.focus + instFieldCount - 1) % instFieldCount }
 
 // toggleVerify flips the verify_tls field.
@@ -187,7 +188,8 @@ func (f *instanceForm) render(th *theme.Theme, w, h int) string {
 		f.inputLine(th, fieldPasswordEnv, "Pass env", f.passwordEnv.View()),
 		f.toggleLine(th, fieldVerifyTLS, "Verify TLS", tls),
 		"",
-		th.SubtleStyle().Render("tab next · ←/→ toggle · enter save · esc cancel"),
+		th.SubtleStyle().
+			Render("tab next · ←/→ toggle · enter save · esc cancel"),
 	}
 
 	panelW := clampInt(w-4, 24, 72)
@@ -196,20 +198,44 @@ func (f *instanceForm) render(th *theme.Theme, w, h int) string {
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(panelW).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		w,
+		h,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		surfaceWhitespace(th),
+	)
 }
 
-func (f *instanceForm) toggleLine(th *theme.Theme, field instField, label, value string) string {
-	return f.fieldLabel(th, field, label) + "  " + th.TextStyle().Render("‹ "+value+" ›")
+func (f *instanceForm) toggleLine(
+	th *theme.Theme,
+	field instField,
+	label, value string,
+) string {
+	return f.fieldLabel(
+		th,
+		field,
+		label,
+	) + "  " + th.TextStyle().
+		Render("‹ "+value+" ›")
 }
 
-func (f *instanceForm) inputLine(th *theme.Theme, field instField, label, view string) string {
+func (f *instanceForm) inputLine(
+	th *theme.Theme,
+	field instField,
+	label, view string,
+) string {
 	return f.fieldLabel(th, field, label) + "  " + view
 }
 
-func (f *instanceForm) fieldLabel(th *theme.Theme, field instField, label string) string {
+func (f *instanceForm) fieldLabel(
+	th *theme.Theme,
+	field instField,
+	label string,
+) string {
 	marker := "  "
 	style := th.SubtleStyle()
 	if f.focus == field {

--- a/internal/tui/screens/settings/settings.go
+++ b/internal/tui/screens/settings/settings.go
@@ -115,9 +115,11 @@ func (m *Model) Init() tea.Cmd { return nil }
 func (m *Model) Title() string { return "Settings" }
 
 // CapturesInput reports whether a text field or modal is focused, so the root
-// delivers raw keys instead of firing global shortcuts (see core.InputCapturer).
+// delivers raw keys instead of firing global shortcuts (see
+// core.InputCapturer).
 func (m *Model) CapturesInput() bool {
-	return m.filtering || m.edit != nil || m.connForm != nil || m.themePicker != nil
+	return m.filtering || m.edit != nil || m.connForm != nil ||
+		m.themePicker != nil
 }
 
 // Focus activates the screen and fetches the live config tree.
@@ -316,10 +318,34 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.filtering {
 		return m.handleFilterKey(msg)
 	}
+	switch msg.String() {
+	case "tab":
+		m.cycleMode(1)
+		return m, nil
+	case "shift+tab":
+		m.cycleMode(-1)
+		return m, nil
+	}
 	if m.mode == modeConnections {
 		return m.handleConnKey(msg)
 	}
 	return m.handleTreeKey(msg)
+}
+
+// cycleMode advances the active section tab by delta, wrapping around, and
+// rebuilds the connections rows when landing there. The single-key c toggle and
+// the tab keys share this so both stay in lockstep.
+func (m *Model) cycleMode(delta int) {
+	n := len(sectionLabels)
+	next := screenMode((int(m.mode) + delta + n) % n)
+	if next == m.mode {
+		return
+	}
+	m.mode = next
+	m.err = nil
+	if next == modeConnections && m.ctx.Config != nil {
+		m.rebuildConnRows()
+	}
 }
 
 // handleTreeKey routes config-tree shortcuts and otherwise defers to the table.
@@ -434,6 +460,7 @@ func (m *Model) applyFilter() {
 func (m *Model) syncTreeRows() {
 	widths := computeTreeWidths(m.w)
 	idx := m.tree.Cursor()
+	m.tree.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.tree.SetRows(treeRows(m.ctx.Theme, m.visible, widths))
 	if idx >= len(m.visible) {
 		idx = len(m.visible) - 1
@@ -460,37 +487,53 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	// Join with plain newlines rather than lipgloss.JoinVertical: JoinVertical
+	// pads short lines to the block width with *unstyled* spaces, which bleed
+	// the terminal background. Newline-joined, the outer SurfaceStyle pads
+	// every line
+	// itself and re-applies the surface background across the padding.
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
 
+// sectionLabels is the ordered tab set, indexed by screenMode.
+var sectionLabels = []string{"Configuration", "Connections"}
+
+// sectionBlurb is the one-line explanation shown beneath the tabs for each
+// mode,
+// so the screen teaches what it does instead of relying on muscle memory.
+func sectionBlurb(mode screenMode) string {
+	if mode == modeConnections {
+		return "Manage Pi-hole instances and the app theme · " +
+			"a add · e edit · x delete · t theme"
+	}
+	return "Live FTL configuration · enter edits a key and writes it " +
+		"back instantly · / filter · r refresh"
+}
+
 func (m *Model) renderHeader(th *theme.Theme) string {
-	title := th.AccentStyle().Bold(true).Render(m.Title())
-
-	modeLabel := "Configuration"
+	var right string
 	if m.mode == modeConnections {
-		modeLabel = "Connections"
-	}
-	chip := lipgloss.NewStyle().
-		Foreground(th.Surface).
-		Background(th.Accent).
-		Padding(0, 1).
-		Render(modeLabel)
-
-	var count string
-	if m.mode == modeConnections {
-		count = th.SubtleStyle().Render(fmt.Sprintf("%d instances", m.instanceCount()))
+		right = fmt.Sprintf("%d instances", m.instanceCount())
 	} else {
-		count = th.SubtleStyle().Render(fmt.Sprintf("%d shown · %d total", len(m.visible), len(m.leaves)))
+		right = fmt.Sprintf(
+			"%d shown · %d total",
+			len(m.visible),
+			len(m.leaves),
+		)
 	}
 
-	left := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", chip)
-	gap := m.w - lipgloss.Width(left) - lipgloss.Width(count)
-	if gap < 1 {
-		gap = 1
-	}
-	line := left + strings.Repeat(" ", gap) + count
+	tabs := components.SectionTabs{
+		Title:  m.Title(),
+		Labels: sectionLabels,
+		Active: int(m.mode),
+		Right:  right,
+		Width:  m.w,
+	}.Render(th)
+
+	explain := th.SubtleStyle().
+		Render(truncate(sectionBlurb(m.mode), maxInt(m.w, 8)))
 
 	second := ""
 	if m.filtering {
@@ -498,7 +541,10 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	} else if m.err != nil {
 		second = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, second)
+	// Newline-joined, not JoinVertical: the outer SurfaceStyle in View pads
+	// each
+	// line with the surface background, so short header rows don't bleed.
+	return strings.Join([]string{tabs, explain, second}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -520,20 +566,35 @@ func (m *Model) renderBody(th *theme.Theme) string {
 		return m.edit.render(th, m.w, bodyH)
 	}
 	if m.loading && len(m.leaves) == 0 {
-		line := m.spinner.View() + " " + th.SubtleStyle().Render("loading config…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+		line := m.spinner.View() + " " + th.SubtleStyle().
+			Render("loading config…")
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			line,
+			surfaceWhitespace(th),
+		)
 	}
 	if len(m.visible) == 0 {
 		empty := th.SubtleStyle().Render("no config keys match this filter")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			surfaceWhitespace(th),
+		)
 	}
 	return m.tree.View()
 }
 
 func (m *Model) renderFooter(th *theme.Theme) string {
-	hint := "↑↓ navigate · enter edit · / filter · c connections · r refresh"
+	hint := "↑↓ navigate · enter edit · / filter · tab section · r refresh"
 	if m.mode == modeConnections {
-		hint = "↑↓ navigate · a add · e edit · x delete · t theme · c config"
+		hint = "↑↓ navigate · a add · e edit · x delete · t theme · tab section"
 	}
 	return th.SubtleStyle().Render(truncate(hint, maxInt(m.w, 8)))
 }

--- a/internal/tui/screens/settings/settings_test.go
+++ b/internal/tui/screens/settings/settings_test.go
@@ -25,8 +25,17 @@ func newTestConfig(t *testing.T) (*config.Config, string) {
 		Active: "primary",
 		Theme:  theme.NameDeepNight,
 		Instances: []config.Instance{
-			{Name: "primary", URL: "http://pi.hole", Password: "secret-pw", VerifyTLS: boolPtr(true)},
-			{Name: "secondary", URL: "http://pi2.hole", PasswordEnv: "PIHOLE_PW"},
+			{
+				Name:      "primary",
+				URL:       "http://pi.hole",
+				Password:  "secret-pw",
+				VerifyTLS: boolPtr(true),
+			},
+			{
+				Name:        "secondary",
+				URL:         "http://pi2.hole",
+				PasswordEnv: "PIHOLE_PW",
+			},
 		},
 	}
 	path := filepath.Join(t.TempDir(), "config.yaml")
@@ -94,9 +103,20 @@ func TestFlattenConfigProducesSortedDottedLeaves(t *testing.T) {
 	leaves := flattenConfig(tree)
 
 	// Assert
-	want := []string{"dns.blocking.active", "dns.host", "dns.port", "misc.nice", "webserver.port"}
+	want := []string{
+		"dns.blocking.active",
+		"dns.host",
+		"dns.port",
+		"misc.nice",
+		"webserver.port",
+	}
 	if len(leaves) != len(want) {
-		t.Fatalf("expected %d leaves, got %d: %+v", len(want), len(leaves), leaves)
+		t.Fatalf(
+			"expected %d leaves, got %d: %+v",
+			len(want),
+			len(leaves),
+			leaves,
+		)
 	}
 	for i, p := range want {
 		if leaves[i].path != p {
@@ -105,13 +125,25 @@ func TestFlattenConfigProducesSortedDottedLeaves(t *testing.T) {
 	}
 	// Types preserved.
 	if leaves[0].value != true {
-		t.Fatalf("expected bool leaf, got %T %v", leaves[0].value, leaves[0].value)
+		t.Fatalf(
+			"expected bool leaf, got %T %v",
+			leaves[0].value,
+			leaves[0].value,
+		)
 	}
 	if leaves[2].value != 53 {
-		t.Fatalf("expected int leaf 53, got %T %v", leaves[2].value, leaves[2].value)
+		t.Fatalf(
+			"expected int leaf 53, got %T %v",
+			leaves[2].value,
+			leaves[2].value,
+		)
 	}
 	if leaves[1].value != "pi.hole" {
-		t.Fatalf("expected string leaf, got %T %v", leaves[1].value, leaves[1].value)
+		t.Fatalf(
+			"expected string leaf, got %T %v",
+			leaves[1].value,
+			leaves[1].value,
+		)
 	}
 }
 
@@ -195,7 +227,11 @@ func TestFocusSetsLoadingAndBumpsEpoch(t *testing.T) {
 		t.Fatalf("focus should set loading")
 	}
 	if m.epoch != startEpoch+1 {
-		t.Fatalf("focus should bump epoch: got %d want %d", m.epoch, startEpoch+1)
+		t.Fatalf(
+			"focus should bump epoch: got %d want %d",
+			m.epoch,
+			startEpoch+1,
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("focus should return a fetch command")
@@ -267,7 +303,10 @@ func TestPatchSuccessTriggersRefetch(t *testing.T) {
 
 	// Assert
 	if m.epoch != 5 {
-		t.Fatalf("successful patch should bump epoch for refetch, got %d", m.epoch)
+		t.Fatalf(
+			"successful patch should bump epoch for refetch, got %d",
+			m.epoch,
+		)
 	}
 	if !m.loading {
 		t.Fatalf("refetch should set loading")
@@ -380,7 +419,10 @@ func TestAddInstanceSubmitWritesFileAndEmits(t *testing.T) {
 	}
 	// Local config updated.
 	if len(m.ctx.Config.Instances) != 3 {
-		t.Fatalf("expected 3 instances after add, got %d", len(m.ctx.Config.Instances))
+		t.Fatalf(
+			"expected 3 instances after add, got %d",
+			len(m.ctx.Config.Instances),
+		)
 	}
 	// Command emits InstancesChangedMsg.
 	if cmd == nil {
@@ -392,7 +434,10 @@ func TestAddInstanceSubmitWritesFileAndEmits(t *testing.T) {
 		t.Fatalf("expected InstancesChangedMsg, got %T", msg)
 	}
 	if len(changed.Config.Instances) != 3 {
-		t.Fatalf("emitted config should carry 3 instances, got %d", len(changed.Config.Instances))
+		t.Fatalf(
+			"emitted config should carry 3 instances, got %d",
+			len(changed.Config.Instances),
+		)
 	}
 }
 
@@ -438,7 +483,10 @@ func TestDeleteInstanceConfirmEmits(t *testing.T) {
 		t.Fatalf("confirming should hide the dialog")
 	}
 	if len(m.ctx.Config.Instances) != 1 {
-		t.Fatalf("expected 1 instance after delete, got %d", len(m.ctx.Config.Instances))
+		t.Fatalf(
+			"expected 1 instance after delete, got %d",
+			len(m.ctx.Config.Instances),
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("confirming delete should return a command")
@@ -451,12 +499,21 @@ func TestDeleteInstanceConfirmEmits(t *testing.T) {
 func TestDeleteLastInstanceIsRejected(t *testing.T) {
 	// Arrange: config with a single instance.
 	c := &config.Config{
-		Active:    "only",
-		Theme:     theme.NameDeepNight,
-		Instances: []config.Instance{{Name: "only", URL: "http://pi.hole", Password: "x"}},
+		Active: "only",
+		Theme:  theme.NameDeepNight,
+		Instances: []config.Instance{
+			{Name: "only", URL: "http://pi.hole", Password: "x"},
+		},
 	}
 	path := filepath.Join(t.TempDir(), "config.yaml")
-	m := New(&core.AppContext{API: pihole.New("http://x", "pw"), Theme: theme.DeepNight(), Config: c, ConfigPath: path})
+	m := New(
+		&core.AppContext{
+			API:        pihole.New("http://x", "pw"),
+			Theme:      theme.DeepNight(),
+			Config:     c,
+			ConfigPath: path,
+		},
+	)
 	m.SetSize(100, 24)
 	_, _ = m.Update(keyPress("c"))
 	_, _ = m.Update(keyPress("x"))

--- a/internal/tui/screens/settings/settings_view_test.go
+++ b/internal/tui/screens/settings/settings_view_test.go
@@ -61,7 +61,8 @@ func TestBlurClearsOverlaysAndCancels(t *testing.T) {
 	if m.focused {
 		t.Fatalf("Blur should clear focus")
 	}
-	if m.filtering || m.edit != nil || m.connForm != nil || m.themePicker != nil {
+	if m.filtering || m.edit != nil || m.connForm != nil ||
+		m.themePicker != nil {
 		t.Fatalf("Blur should tear down all overlays")
 	}
 	if m.pendingDel != -1 {
@@ -107,7 +108,10 @@ func TestViewConfigEmptyFilterShowsNoMatch(t *testing.T) {
 	m.filter = "zzz-nothing-matches"
 	m.applyFilter()
 	if out := m.View().Content; !strings.Contains(out, "no config keys match") {
-		t.Fatalf("filtered-to-empty should render the no-match message:\n%s", out)
+		t.Fatalf(
+			"filtered-to-empty should render the no-match message:\n%s",
+			out,
+		)
 	}
 }
 
@@ -156,7 +160,10 @@ func TestViewConnEmptyInstances(t *testing.T) {
 	m := bigModel(t)
 	_, _ = m.Update(keyPress("c"))
 	m.ctx.Config.Instances = nil
-	if out := m.View().Content; !strings.Contains(out, "no instances configured") {
+	if out := m.View().Content; !strings.Contains(
+		out,
+		"no instances configured",
+	) {
 		t.Fatalf("zero instances should render the empty message:\n%s", out)
 	}
 }
@@ -262,7 +269,10 @@ func TestLeafEditTextTypingEditsInput(t *testing.T) {
 	_, _ = m.Update(keyPress("enter"))
 	_, _ = m.Update(keyPress("z"))
 	if !strings.Contains(m.edit.input.Value(), "z") {
-		t.Fatalf("typing should edit the text input, got %q", m.edit.input.Value())
+		t.Fatalf(
+			"typing should edit the text input, got %q",
+			m.edit.input.Value(),
+		)
 	}
 }
 
@@ -298,7 +308,10 @@ func TestFilterTypingThenEscRestores(t *testing.T) {
 		t.Fatalf("esc should not change the applied filter, got %q", m.filter)
 	}
 	if m.filterInput.Value() != "dns" {
-		t.Fatalf("esc should reset the box to the applied filter, got %q", m.filterInput.Value())
+		t.Fatalf(
+			"esc should reset the box to the applied filter, got %q",
+			m.filterInput.Value(),
+		)
 	}
 }
 
@@ -367,10 +380,16 @@ func TestDeleteActiveInstanceReassignsActive(t *testing.T) {
 	_, _ = m.Update(keyPress("x"))
 	_, cmd := m.Update(keyPress("y"))
 	if len(m.ctx.Config.Instances) != 1 {
-		t.Fatalf("expected 1 instance after delete, got %d", len(m.ctx.Config.Instances))
+		t.Fatalf(
+			"expected 1 instance after delete, got %d",
+			len(m.ctx.Config.Instances),
+		)
 	}
 	if m.ctx.Config.Active != "secondary" {
-		t.Fatalf("deleting the active instance should reassign Active, got %q", m.ctx.Config.Active)
+		t.Fatalf(
+			"deleting the active instance should reassign Active, got %q",
+			m.ctx.Config.Active,
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("delete should emit a command")
@@ -390,7 +409,10 @@ func TestEditActiveInstanceRenamesActivePointer(t *testing.T) {
 		t.Fatalf("valid rename should not error: %v", m.err)
 	}
 	if m.ctx.Config.Active != "primary-renamed" {
-		t.Fatalf("renaming the active instance should follow the Active pointer, got %q", m.ctx.Config.Active)
+		t.Fatalf(
+			"renaming the active instance should follow the Active pointer, got %q",
+			m.ctx.Config.Active,
+		)
 	}
 	if cmd == nil {
 		t.Fatalf("valid edit should emit a command")
@@ -430,7 +452,10 @@ func TestConnFormTypingRoutesToFocusedInput(t *testing.T) {
 	_, _ = m.Update(keyPress("a"))
 	_, _ = m.Update(keyPress("q")) // focus is name
 	if !strings.Contains(m.connForm.name.Value(), "q") {
-		t.Fatalf("typing should route to the focused input, got %q", m.connForm.name.Value())
+		t.Fatalf(
+			"typing should route to the focused input, got %q",
+			m.connForm.name.Value(),
+		)
 	}
 }
 
@@ -548,7 +573,10 @@ func TestNewLeafEditTextPath(t *testing.T) {
 		t.Fatalf("string leaf should not be a bool editor")
 	}
 	if e.input.Value() != "pi.hole" {
-		t.Fatalf("editor should pre-fill the current value, got %q", e.input.Value())
+		t.Fatalf(
+			"editor should pre-fill the current value, got %q",
+			e.input.Value(),
+		)
 	}
 }
 
@@ -634,7 +662,8 @@ func TestThemePickerRenderMarksCurrent(t *testing.T) {
 }
 
 func TestThemePickerBoundsAndSelected(t *testing.T) {
-	p := newThemePicker(theme.NameDeepNight)
+	// NameAuto is the first entry, so the cursor starts at the top.
+	p := newThemePicker(theme.NameAuto)
 	p.up() // already at top; no move
 	if p.cursor != 0 {
 		t.Fatalf("up at top should stay at 0")

--- a/internal/tui/screens/settings/tree.go
+++ b/internal/tui/screens/settings/tree.go
@@ -23,7 +23,8 @@ type leaf struct {
 
 // flattenConfig walks a nested config tree into a sorted, flat list of scalar
 // leaves keyed by dotted paths. Nested objects are descended into; a detailed
-// leaf descriptor (as returned by GET /config?detailed=true) is collapsed to its
+// leaf descriptor (as returned by GET /config?detailed=true) is collapsed to
+// its
 // underlying value so both detailed and raw trees flatten the same way.
 func flattenConfig(m map[string]any) []leaf {
 	var out []leaf
@@ -81,7 +82,8 @@ func filterLeaves(leaves []leaf, query string) []leaf {
 	return out
 }
 
-// stringifyValue renders a leaf value for display and for pre-filling an editor.
+// stringifyValue renders a leaf value for display and for pre-filling an
+// editor.
 func stringifyValue(v any) string {
 	switch x := v.(type) {
 	case nil:
@@ -221,7 +223,10 @@ func (e *leafEdit) render(th *theme.Theme, w, h int) string {
 
 	var valueLine string
 	if e.isBool {
-		valueLine = th.SubtleStyle().Render("Value") + "  " + th.TextStyle().Render("‹ "+strconv.FormatBool(e.boolVal)+" ›")
+		valueLine = th.SubtleStyle().
+			Render("Value") +
+			"  " + th.TextStyle().
+			Render("‹ "+strconv.FormatBool(e.boolVal)+" ›")
 	} else {
 		valueLine = th.SubtleStyle().Render("Value") + "  " + e.input.View()
 	}
@@ -239,9 +244,16 @@ func (e *leafEdit) render(th *theme.Theme, w, h int) string {
 		BorderForeground(th.Border).
 		Padding(1, 2).
 		Width(panelW).
-		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+		Render(strings.Join(lines, "\n"))
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, panel)
+	return lipgloss.Place(
+		w,
+		h,
+		lipgloss.Center,
+		lipgloss.Top,
+		panel,
+		surfaceWhitespace(th),
+	)
 }
 
 // --- tree table rendering ---

--- a/internal/tui/screens/settings/util.go
+++ b/internal/tui/screens/settings/util.go
@@ -1,11 +1,17 @@
 package settings
 
-import "time"
+import (
+	"time"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/zackkitzmiller/tihole/internal/theme"
+)
 
 const (
 	fetchTimeout = 8 * time.Second
 
-	headerHeight = 2 // title/chip line + banner/spacer
+	headerHeight = 3 // section-tabs line + explanation line + banner/spacer
 	footerHeight = 1 // hint line
 
 	treeCellPad = 2
@@ -14,7 +20,8 @@ const (
 	ellipsis = "…"
 )
 
-// truncate shortens s to at most width display cells, appending an ellipsis when
+// truncate shortens s to at most width display cells, appending an ellipsis
+// when
 // it must cut. Rune-aware so multibyte content is not split mid-rune.
 func truncate(s string, width int) string {
 	if width <= 0 {
@@ -28,6 +35,15 @@ func truncate(s string, width int) string {
 		return ellipsis
 	}
 	return string(r[:width-1]) + ellipsis
+}
+
+// surfaceWhitespace paints lipgloss.Place's fill with the surface background so
+// centered panels and empty states don't bleed the terminal background around
+// the placed content.
+func surfaceWhitespace(th *theme.Theme) lipgloss.WhitespaceOption {
+	return lipgloss.WithWhitespaceStyle(
+		lipgloss.NewStyle().Background(th.Surface),
+	)
 }
 
 func maxInt(a, b int) int {

--- a/internal/tui/screens/system/actions.go
+++ b/internal/tui/screens/system/actions.go
@@ -73,7 +73,8 @@ func (m *Model) handleActionsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// destructiveHint augments a failed destructive action with an allow_destructive
+// destructiveHint augments a failed destructive action with an
+// allow_destructive
 // remediation note when the error looks like a forbidden/destructive rejection.
 func destructiveHint(err error) error {
 	if err == nil {
@@ -81,9 +82,15 @@ func destructiveHint(err error) error {
 	}
 	var apiErr *pihole.APIError
 	if errors.As(err, &apiErr) {
-		low := strings.ToLower(apiErr.Message + " " + apiErr.Key + " " + apiErr.Hint)
-		if apiErr.Status == 403 || strings.Contains(low, "destructive") || strings.Contains(low, "forbidden") {
-			return fmt.Errorf("%w — enable allow_destructive in the FTL config to permit this", err)
+		low := strings.ToLower(
+			apiErr.Message + " " + apiErr.Key + " " + apiErr.Hint,
+		)
+		if apiErr.Status == 403 || strings.Contains(low, "destructive") ||
+			strings.Contains(low, "forbidden") {
+			return fmt.Errorf(
+				"%w — enable allow_destructive in the FTL config to permit this",
+				err,
+			)
 		}
 	}
 	return err
@@ -93,7 +100,11 @@ func destructiveHint(err error) error {
 func (m *Model) renderActions(th *theme.Theme, bodyH int) string {
 	items := actionItems()
 	var lines []string
-	lines = append(lines, th.AccentStyle().Bold(true).Render("Destructive actions"), "")
+	lines = append(
+		lines,
+		th.AccentStyle().Bold(true).Render("Destructive actions"),
+		"",
+	)
 	for i, item := range items {
 		marker := "  "
 		style := th.TextStyle()
@@ -104,8 +115,12 @@ func (m *Model) renderActions(th *theme.Theme, bodyH int) string {
 		lines = append(lines, marker+style.Render(item.label))
 		lines = append(lines, "    "+th.SubtleStyle().Render(item.desc))
 	}
-	lines = append(lines, "", th.SubtleStyle().Render("enter run · may require allow_destructive"))
+	lines = append(
+		lines,
+		"",
+		th.SubtleStyle().Render("enter run · may require allow_destructive"),
+	)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	content := strings.Join(lines, "\n")
 	return lipgloss.NewStyle().MaxHeight(bodyH).Render(content)
 }

--- a/internal/tui/screens/system/info.go
+++ b/internal/tui/screens/system/info.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -55,7 +56,10 @@ func (m *Model) fetchInfo() tea.Cmd {
 				}
 				continue
 			}
-			sections = append(sections, infoSection{name: name, rows: flattenInfo(data)})
+			sections = append(
+				sections,
+				infoSection{name: name, rows: flattenInfo(data)},
+			)
 		}
 		return infoMsg{epoch: e, sections: sections, err: firstErr}
 	}, m.spinner.Tick)
@@ -127,7 +131,14 @@ func (m *Model) renderInfo(th *theme.Theme, bodyH int) string {
 	}
 	if len(m.info) == 0 {
 		empty := th.SubtleStyle().Render("no info available")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 
 	keyW := 16
@@ -136,13 +147,17 @@ func (m *Model) renderInfo(th *theme.Theme, bodyH int) string {
 		heading := th.AccentStyle().Bold(true).Render(sec.name)
 		lines := []string{heading}
 		for _, row := range sec.rows {
-			label := th.SubtleStyle().Width(keyW).Render(truncate(row.key, keyW))
-			val := th.TextStyle().Render(truncate(row.val, maxInt(m.w-keyW-4, 8)))
+			label := th.SubtleStyle().
+				Background(th.Surface).
+				Width(keyW).
+				Render(truncate(row.key, keyW))
+			val := th.TextStyle().
+				Render(truncate(row.val, maxInt(m.w-keyW-4, 8)))
 			lines = append(lines, label+"  "+val)
 		}
-		panels = append(panels, lipgloss.JoinVertical(lipgloss.Left, lines...))
+		panels = append(panels, strings.Join(lines, "\n"))
 	}
 
-	content := lipgloss.JoinVertical(lipgloss.Left, panels...)
+	content := strings.Join(panels, "\n")
 	return lipgloss.NewStyle().MaxHeight(bodyH).Render(content)
 }

--- a/internal/tui/screens/system/logtail.go
+++ b/internal/tui/screens/system/logtail.go
@@ -48,7 +48,8 @@ func (m *Model) fetchLog() tea.Cmd {
 	}
 }
 
-// startLogTail begins the live tail: an immediate fetch plus the recurring tick.
+// startLogTail begins the live tail: an immediate fetch plus the recurring
+// tick.
 func (m *Model) startLogTail() tea.Cmd {
 	return tea.Batch(m.fetchLog(), m.tick(), m.spinner.Tick)
 }
@@ -71,7 +72,12 @@ func (m *Model) appendLog(page pihole.DNSLogPage) {
 
 // formatLogLine renders one resolver log line as "HH:MM:SS  message".
 func formatLogLine(line pihole.DNSLogLine) string {
-	return formatEpoch(line.Timestamp) + "  " + strings.TrimRight(line.Message, "\n")
+	return formatEpoch(
+		line.Timestamp,
+	) + "  " + strings.TrimRight(
+		line.Message,
+		"\n",
+	)
 }
 
 // handleLogKey lets the viewport handle scroll keys on the Log tab.
@@ -88,7 +94,14 @@ func (m *Model) renderLog(th *theme.Theme, bodyH int) string {
 	}
 	if len(m.logLines) == 0 {
 		empty := th.SubtleStyle().Render("waiting for log lines…")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 	return m.viewport.View()
 }

--- a/internal/tui/screens/system/messages.go
+++ b/internal/tui/screens/system/messages.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/zackkitzmiller/tihole/internal/pihole"
 	"github.com/zackkitzmiller/tihole/internal/theme"
+	"github.com/zackkitzmiller/tihole/internal/tui/components"
 )
 
 const (
@@ -110,6 +111,7 @@ func (m *Model) syncMsgRows() {
 	for i, msg := range m.messages {
 		rows[i] = table.Row(messageToRow(msg, widths))
 	}
+	m.msgTable.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.msgTable.SetRows(rows)
 	if idx >= len(rows) {
 		idx = len(rows) - 1
@@ -130,7 +132,11 @@ func (m *Model) handleMessagesKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return api.DeleteMessages(ctx, []int{id})
 			}
 			m.pendingReload = true
-			m.confirm = m.confirm.Show("Dismiss message?", truncate(dm.Plain, 60), true)
+			m.confirm = m.confirm.Show(
+				"Dismiss message?",
+				truncate(dm.Plain, 60),
+				true,
+			)
 		}
 		return m, nil
 	case "X":
@@ -143,7 +149,11 @@ func (m *Model) handleMessagesKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return api.DeleteMessages(ctx, ids)
 			}
 			m.pendingReload = true
-			m.confirm = m.confirm.Show("Dismiss all messages?", strconv.Itoa(len(ids))+" messages", true)
+			m.confirm = m.confirm.Show(
+				"Dismiss all messages?",
+				strconv.Itoa(len(ids))+" messages",
+				true,
+			)
 		}
 		return m, nil
 	}
@@ -159,7 +169,14 @@ func (m *Model) renderMessages(th *theme.Theme, bodyH int) string {
 	}
 	if len(m.messages) == 0 {
 		empty := th.SubtleStyle().Render("no diagnosis messages")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 	m.syncMsgRows()
 	return m.msgTable.View()

--- a/internal/tui/screens/system/network.go
+++ b/internal/tui/screens/system/network.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/zackkitzmiller/tihole/internal/pihole"
 	"github.com/zackkitzmiller/tihole/internal/theme"
+	"github.com/zackkitzmiller/tihole/internal/tui/components"
 )
 
 const (
@@ -98,7 +99,8 @@ func deviceToRow(d pihole.NetworkDevice, widths []int) []string {
 	}
 }
 
-// formatUnixTime renders a unix-seconds timestamp as HH:MM:SS, or a dash when 0.
+// formatUnixTime renders a unix-seconds timestamp as HH:MM:SS, or a dash when
+// 0.
 func formatUnixTime(sec int64) string {
 	if sec <= 0 {
 		return "-"
@@ -136,6 +138,7 @@ func (m *Model) syncNetRows() {
 	for i, d := range m.devices {
 		rows[i] = table.Row(deviceToRow(d, widths))
 	}
+	m.netTable.SetStyles(components.TableStyles(m.ctx.Theme))
 	m.netTable.SetRows(rows)
 	if idx >= len(rows) {
 		idx = len(rows) - 1
@@ -157,7 +160,11 @@ func (m *Model) handleNetworkKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return api.DeleteNetworkDevice(ctx, id)
 			}
 			m.pendingReload = true
-			m.confirm = m.confirm.Show("Delete device?", ip+" · "+d.HWAddr, true)
+			m.confirm = m.confirm.Show(
+				"Delete device?",
+				ip+" · "+d.HWAddr,
+				true,
+			)
 		}
 		return m, nil
 	}
@@ -173,7 +180,14 @@ func (m *Model) renderNetwork(th *theme.Theme, bodyH int) string {
 	}
 	if len(m.devices) == 0 {
 		empty := th.SubtleStyle().Render("no network devices")
-		return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, empty)
+		return lipgloss.Place(
+			m.w,
+			bodyH,
+			lipgloss.Center,
+			lipgloss.Center,
+			empty,
+			th.SurfaceWhitespace(),
+		)
 	}
 	m.syncNetRows()
 	return m.netTable.View()

--- a/internal/tui/screens/system/system.go
+++ b/internal/tui/screens/system/system.go
@@ -1,14 +1,17 @@
 // Package system implements the PiHole v6 System/Tools screen: a tabbed surface
 // over FTL diagnostics and maintenance. Tabs cover read-only Info panels, the
-// diagnosis Messages table, the Network device table, a live DNS Log tail, and a
+// diagnosis Messages table, the Network device table, a live DNS Log tail, and
+// a
 // menu of destructive Actions. Data loads lazily per tab on focus/switch; only
-// the Log tab polls continuously. All I/O is deferred to tea.Cmd closures with a
-// timeout context, stale (wrong-epoch) results are dropped, and errors surface in
+// the Log tab polls continuously. All I/O is deferred to tea.Cmd closures with
+// a timeout context, stale (wrong-epoch) results are dropped, and errors
+// surface in
 // an inline banner. It satisfies core.Screen.
 package system
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -118,7 +121,8 @@ func (m *Model) Focus() tea.Cmd {
 	return m.loadActive()
 }
 
-// Blur deactivates the screen, cancels any in-flight request, and stops polling.
+// Blur deactivates the screen, cancels any in-flight request, and stops
+// polling.
 func (m *Model) Blur() {
 	m.focused = false
 	m.confirm = m.confirm.Hide()
@@ -132,11 +136,23 @@ func (m *Model) Blur() {
 // Help returns screen-local key bindings for the help bar.
 func (m *Model) Help() []key.Binding {
 	return []key.Binding{
-		key.NewBinding(key.WithKeys("tab", "f"), key.WithHelp("tab", "next tab")),
-		key.NewBinding(key.WithKeys("left", "right"), key.WithHelp("←→", "switch tab")),
+		key.NewBinding(
+			key.WithKeys("tab", "f"),
+			key.WithHelp("tab", "next tab"),
+		),
+		key.NewBinding(
+			key.WithKeys("left", "right"),
+			key.WithHelp("←→", "switch tab"),
+		),
 		key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
-		key.NewBinding(key.WithKeys("x", "delete"), key.WithHelp("x", "delete")),
-		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "run action")),
+		key.NewBinding(
+			key.WithKeys("x", "delete"),
+			key.WithHelp("x", "delete"),
+		),
+		key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "run action"),
+		),
 	}
 }
 
@@ -198,7 +214,10 @@ func (m *Model) switchTab(t tab) (tea.Model, tea.Cmd) {
 
 // mutate wraps a write in a timeout context and reports the outcome as a
 // mutationMsg; loading is set so the spinner shows.
-func (m *Model) mutate(op func(context.Context, *pihole.Client) error, reload bool) tea.Cmd {
+func (m *Model) mutate(
+	op func(context.Context, *pihole.Client) error,
+	reload bool,
+) tea.Cmd {
 	ctx := m.newCtx()
 	e := m.epoch
 	api := m.ctx.API
@@ -361,7 +380,7 @@ func (m *Model) View() tea.View {
 	body := m.renderBody(th)
 	footer := m.renderFooter(th)
 
-	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	content := strings.Join([]string{header, body, footer}, "\n")
 	view := th.SurfaceStyle().Width(m.w).Height(m.h).Render(content)
 	return tea.NewView(view)
 }
@@ -383,7 +402,7 @@ func (m *Model) renderHeader(th *theme.Theme) string {
 	if m.err != nil {
 		second = m.errBanner(th)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, line, second)
+	return strings.Join([]string{line, second}, "\n")
 }
 
 func (m *Model) errBanner(th *theme.Theme) string {
@@ -422,7 +441,14 @@ func (m *Model) renderBody(th *theme.Theme) string {
 // spinnerLine centers the loading spinner with a label in the body area.
 func (m *Model) spinnerLine(th *theme.Theme, label string, bodyH int) string {
 	line := m.spinner.View() + " " + th.SubtleStyle().Render(label)
-	return lipgloss.Place(m.w, bodyH, lipgloss.Center, lipgloss.Center, line)
+	return lipgloss.Place(
+		m.w,
+		bodyH,
+		lipgloss.Center,
+		lipgloss.Center,
+		line,
+		th.SurfaceWhitespace(),
+	)
 }
 
 func (m *Model) renderFooter(th *theme.Theme) string {

--- a/internal/tui/screens/system/system_test.go
+++ b/internal/tui/screens/system/system_test.go
@@ -145,7 +145,9 @@ func TestMessagesMsgPopulatesStateAndClearsLoading(t *testing.T) {
 	m := newTestModel()
 	m.epoch = 2
 	m.loading = true
-	msgs := []pihole.DiagnosisMessage{{ID: 1, Type: "DNSMASQ_WARN", Plain: "warn"}}
+	msgs := []pihole.DiagnosisMessage{
+		{ID: 1, Type: "DNSMASQ_WARN", Plain: "warn"},
+	}
 
 	// Act
 	_, _ = m.Update(messagesMsg{epoch: 2, messages: msgs, count: 1})
@@ -155,7 +157,11 @@ func TestMessagesMsgPopulatesStateAndClearsLoading(t *testing.T) {
 		t.Fatalf("messagesMsg should clear loading")
 	}
 	if len(m.messages) != 1 || m.msgCount != 1 {
-		t.Fatalf("messagesMsg should populate messages+count: %+v count=%d", m.messages, m.msgCount)
+		t.Fatalf(
+			"messagesMsg should populate messages+count: %+v count=%d",
+			m.messages,
+			m.msgCount,
+		)
 	}
 }
 
@@ -229,7 +235,12 @@ func TestErrorMsgSetsBanner(t *testing.T) {
 	m.loading = true
 
 	// Act
-	_, _ = m.Update(messagesMsg{epoch: 5, err: &pihole.APIError{Status: 500, Message: "boom"}})
+	_, _ = m.Update(
+		messagesMsg{
+			epoch: 5,
+			err:   &pihole.APIError{Status: 500, Message: "boom"},
+		},
+	)
 
 	// Assert
 	if m.err == nil {
@@ -247,7 +258,9 @@ func TestUpdateIgnoresStaleFetchResult(t *testing.T) {
 	m.loading = true
 
 	// Act
-	_, _ = m.Update(networkMsg{epoch: 8, devices: []pihole.NetworkDevice{{ID: 1}}})
+	_, _ = m.Update(
+		networkMsg{epoch: 8, devices: []pihole.NetworkDevice{{ID: 1}}},
+	)
 
 	// Assert
 	if len(m.devices) != 0 {
@@ -308,7 +321,9 @@ func TestMessagesDeleteArmsConfirmThenRunsDelete(t *testing.T) {
 	// Arrange
 	m := newTestModel()
 	m.activeTab = tabMessages
-	m.messages = []pihole.DiagnosisMessage{{ID: 11, Type: "WARN", Plain: "disk low"}}
+	m.messages = []pihole.DiagnosisMessage{
+		{ID: 11, Type: "WARN", Plain: "disk low"},
+	}
 	m.syncMsgRows()
 
 	// Act: x arms the confirm dialog.
@@ -469,7 +484,11 @@ func TestFlattenInfoKeepsScalarsSortedAndSkipsNested(t *testing.T) {
 
 	// Assert
 	if len(rows) != 4 {
-		t.Fatalf("nested map/slice should be skipped, got %d rows: %+v", len(rows), rows)
+		t.Fatalf(
+			"nested map/slice should be skipped, got %d rows: %+v",
+			len(rows),
+			rows,
+		)
 	}
 	// Sorted by key: dnssec, fraction, uptime, version.
 	if rows[0].key != "dnssec" || rows[0].val != "true" {
@@ -495,7 +514,11 @@ func TestComputeMsgWidthsFitsWithinTotal(t *testing.T) {
 
 	// Assert
 	if len(widths) != len(msgColumnTitles) {
-		t.Fatalf("expected %d columns, got %d", len(msgColumnTitles), len(widths))
+		t.Fatalf(
+			"expected %d columns, got %d",
+			len(msgColumnTitles),
+			len(widths),
+		)
 	}
 	sum := len(msgColumnTitles) * cellPad
 	for _, w := range widths {
@@ -518,7 +541,11 @@ func TestSetSizeSafeAtTinySizes(t *testing.T) {
 
 func TestDestructiveHintAugmentsForbiddenError(t *testing.T) {
 	// Arrange
-	err := &pihole.APIError{Status: 403, Key: "forbidden", Message: "destructive action disabled"}
+	err := &pihole.APIError{
+		Status:  403,
+		Key:     "forbidden",
+		Message: "destructive action disabled",
+	}
 
 	// Act
 	got := destructiveHint(err)

--- a/internal/tui/screens/system/system_view_test.go
+++ b/internal/tui/screens/system/system_view_test.go
@@ -20,8 +20,18 @@ func renderedModel() *Model {
 // sampleMessages returns two diagnosis messages for table rendering.
 func sampleMessages() []pihole.DiagnosisMessage {
 	return []pihole.DiagnosisMessage{
-		{ID: 1, Type: "DNSMASQ_WARN", Plain: "config warning", Timestamp: 1_700_000_000},
-		{ID: 2, Type: "SUBNET", Plain: "overlapping subnet detected", Timestamp: 1_700_000_042},
+		{
+			ID:        1,
+			Type:      "DNSMASQ_WARN",
+			Plain:     "config warning",
+			Timestamp: 1_700_000_000,
+		},
+		{
+			ID:        2,
+			Type:      "SUBNET",
+			Plain:     "overlapping subnet detected",
+			Timestamp: 1_700_000_042,
+		},
 	}
 }
 
@@ -61,7 +71,9 @@ func TestHelpReturnsBindings(t *testing.T) {
 func TestViewInfoTabRendersSectionsAndTabBar(t *testing.T) {
 	// Arrange
 	m := renderedModel()
-	m.info = []infoSection{{name: "ftl", rows: []kv{{"version", "6.0.1"}, {"dnssec", "true"}}}}
+	m.info = []infoSection{
+		{name: "ftl", rows: []kv{{"version", "6.0.1"}, {"dnssec", "true"}}},
+	}
 
 	// Act
 	out := m.View().Content
@@ -123,7 +135,10 @@ func TestViewMessagesLoadingAndEmptyStates(t *testing.T) {
 	}
 
 	m.loading = false
-	if out := m.View().Content; !strings.Contains(out, "no diagnosis messages") {
+	if out := m.View().Content; !strings.Contains(
+		out,
+		"no diagnosis messages",
+	) {
 		t.Fatalf("empty+idle Messages should show placeholder:\n%s", out)
 	}
 }
@@ -166,7 +181,10 @@ func TestViewLogTabRendersViewportAndStates(t *testing.T) {
 	// Arrange: waiting state.
 	m := renderedModel()
 	m.activeTab = tabLog
-	if out := m.View().Content; !strings.Contains(out, "waiting for log lines") {
+	if out := m.View().Content; !strings.Contains(
+		out,
+		"waiting for log lines",
+	) {
 		t.Fatalf("empty+idle Log should show waiting text:\n%s", out)
 	}
 
@@ -179,7 +197,9 @@ func TestViewLogTabRendersViewportAndStates(t *testing.T) {
 	// Arrange: populated viewport.
 	m.loading = false
 	m.appendLog(pihole.DNSLogPage{
-		Log:    []pihole.DNSLogLine{{Timestamp: 1_700_000_000, Message: "query A example.com"}},
+		Log: []pihole.DNSLogLine{
+			{Timestamp: 1_700_000_000, Message: "query A example.com"},
+		},
 		NextID: 5,
 	})
 	if out := m.View().Content; !strings.Contains(out, "example.com") {
@@ -255,7 +275,12 @@ func TestViewRendersEveryTabWithoutPanic(t *testing.T) {
 	m.syncMsgRows()
 	m.devices = sampleDevices()
 	m.syncNetRows()
-	m.appendLog(pihole.DNSLogPage{Log: []pihole.DNSLogLine{{Timestamp: 1, Message: "x"}}, NextID: 2})
+	m.appendLog(
+		pihole.DNSLogPage{
+			Log:    []pihole.DNSLogLine{{Timestamp: 1, Message: "x"}},
+			NextID: 2,
+		},
+	)
 
 	// Act / Assert
 	for t2 := tab(0); t2 < tabCount; t2++ {
@@ -284,7 +309,10 @@ func TestMessagesDismissAllArmsConfirm(t *testing.T) {
 		t.Fatalf("dismiss-all should arm a reloading pending op")
 	}
 	if !strings.Contains(m.confirm.Message, "2 messages") {
-		t.Fatalf("dismiss-all confirm should mention the count, got %q", m.confirm.Message)
+		t.Fatalf(
+			"dismiss-all confirm should mention the count, got %q",
+			m.confirm.Message,
+		)
 	}
 }
 
@@ -365,7 +393,9 @@ func TestMutationReloadTriggersActiveLoad(t *testing.T) {
 
 	// Assert
 	if cmd == nil {
-		t.Fatalf("a successful reloading mutation should refetch the active tab")
+		t.Fatalf(
+			"a successful reloading mutation should refetch the active tab",
+		)
 	}
 	if m.epoch != 5 {
 		t.Fatalf("reloading mutation should bump the epoch, got %d", m.epoch)
@@ -379,14 +409,25 @@ func TestMutationErrorSurfacesDestructiveHint(t *testing.T) {
 	m.loading = true
 
 	// Act
-	_, _ = m.Update(mutationMsg{epoch: 2, err: &pihole.APIError{Status: 403, Message: "destructive disabled"}})
+	_, _ = m.Update(
+		mutationMsg{
+			epoch: 2,
+			err: &pihole.APIError{
+				Status:  403,
+				Message: "destructive disabled",
+			},
+		},
+	)
 
 	// Assert
 	if m.loading {
 		t.Fatalf("an errored mutation should clear loading")
 	}
 	if m.err == nil || !strings.Contains(m.err.Error(), "allow_destructive") {
-		t.Fatalf("a 403 mutation error should carry the destructive hint, got %v", m.err)
+		t.Fatalf(
+			"a 403 mutation error should carry the destructive hint, got %v",
+			m.err,
+		)
 	}
 }
 
@@ -401,7 +442,8 @@ func TestLabelReturnsNamesAndDefault(t *testing.T) {
 
 func TestFirstAddressFallbacks(t *testing.T) {
 	// No IPs.
-	if ip, name := firstAddress(pihole.NetworkDevice{}); ip != "-" || name != "-" {
+	if ip, name := firstAddress(pihole.NetworkDevice{}); ip != "-" ||
+		name != "-" {
 		t.Fatalf("no-IP device should yield dashes, got %q/%q", ip, name)
 	}
 	// Blank fields.
@@ -410,7 +452,9 @@ func TestFirstAddressFallbacks(t *testing.T) {
 		t.Fatalf("blank IP/name should yield dashes, got %q/%q", ip, name)
 	}
 	// Populated.
-	d = pihole.NetworkDevice{IPs: []pihole.NetworkAddress{{IP: "10.0.0.1", Name: "box"}}}
+	d = pihole.NetworkDevice{
+		IPs: []pihole.NetworkAddress{{IP: "10.0.0.1", Name: "box"}},
+	}
 	if ip, name := firstAddress(d); ip != "10.0.0.1" || name != "box" {
 		t.Fatalf("populated address wrong, got %q/%q", ip, name)
 	}

--- a/internal/tui/screens/system/util.go
+++ b/internal/tui/screens/system/util.go
@@ -2,7 +2,8 @@ package system
 
 const ellipsis = "…"
 
-// truncate shortens s to at most width display cells, appending an ellipsis when
+// truncate shortens s to at most width display cells, appending an ellipsis
+// when
 // it must cut. Rune-aware so multibyte strings are not split mid-rune.
 func truncate(s string, width int) string {
 	if width <= 0 {

--- a/justfile
+++ b/justfile
@@ -11,19 +11,19 @@ default:
 
 # Build the binary into ./bin
 build:
-    go build -o {{out}} {{pkg}}
+    go build -o {{ out }} {{ pkg }}
 
 # Run the TUI
 run *args:
-    go run {{pkg}} {{args}}
+    go run {{ pkg }} {{ args }}
 
 # Install to $GOBIN / $GOPATH/bin
 install:
-    go install {{pkg}}
+    go install {{ pkg }}
 
 # Run all tests
 test *args:
-    go test ./... {{args}}
+    go test ./... {{ args }}
 
 # Run tests with coverage summary (house standard: 80%+)
 cover:
@@ -34,13 +34,35 @@ cover:
 cover-html: cover
     go tool cover -html=coverage.out
 
-# Format all Go source
+# Format all Go source (gofmt + golines at 80 cols)
 fmt:
     gofmt -w .
+    PATH="$(go env GOPATH)/bin:$PATH" golines \
+        --base-formatter=gofmt --max-len=80 \
+        --shorten-comments -w . \
+        || go run github.com/segmentio/golines@latest \
+        --base-formatter=gofmt --max-len=80 \
+        --shorten-comments -w .
 
 # Verify formatting (fails if anything is unformatted)
 fmt-check:
-    @test -z "$(gofmt -l .)" || (gofmt -l . && exit 1)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bad="$(gofmt -l .)"
+    if [[ -n "$bad" ]]; then
+        echo "$bad"
+        exit 1
+    fi
+    export PATH="$(go env GOPATH)/bin:$PATH"
+    if ! command -v golines >/dev/null; then
+        go install github.com/segmentio/golines@latest
+    fi
+    bad="$(golines --base-formatter=gofmt --max-len=80 \
+        --shorten-comments -l .)"
+    if [[ -n "$bad" ]]; then
+        echo "$bad"
+        exit 1
+    fi
 
 # go vet
 vet:


### PR DESCRIPTION
## Summary

A cohesive visual overhaul of the tihole TUI (the **Gloss** redesign) plus a fix for the terminal-background bleed and a Query Log quick-classify action.

### Theme & chrome
- **DeepNight** default palette with a signature multi-stop gradient wordmark
- ASCII boot splash before the dashboard
- Host-health strip: CPU / memory / temp gauges + FTL diagnostics
- Blocking promoted to a first-class rail pane; shared `SectionTabs` on every screen

### Background-bleed fix
The terminal's own background (a solid colour **or a background image**) was showing through under/after styled text.
- **Systemic fix:** `tea.View.BackgroundColor = th.Surface` on every `View` return — the renderer emits it as the terminal default, so every unpainted cell now falls back to the theme surface instead of leaking through.
- Sidebar items + gradient wordmark carry `Background(th.Panel)`.
- New `components.TableStyles` (Panel header band, Surface cells, Accent selection) applied to **all 10 tables**, wired through each screen's row-set path so it tracks live `ctrl+t` theme switches.
- Panel bodies built with `strings.Join` over `JoinVertical`; `Place` calls get a Surface whitespace style; progress gauges get a themed `EmptyColor`.

### Query Log quick-classify
- `a` = allow / `b` = block the selected (or detailed) domain straight from the log, behind a confirm dialog, with a transient success toast.

### Dev tooling
- golines format-on-save config (`.editorconfig`, `.vscode`), justfile `fmt` recipe.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — **833 passed** across 18 packages
- [ ] Visual pass: verify no bleed on the left rail / Adlists over a terminal with a background image
- [ ] Exercise `ctrl+t` theme switching across list screens
- [ ] Query Log `a`/`b` allow/block round-trip against a live Pi-hole