### PR TITLE
Rebrand leftover WHETSTONE CSS banners to TIHOLE

### DIFF
--- a/site/ds/colors_and_type.css
+++ b/site/ds/colors_and_type.css
@@ -1,5 +1,5 @@
 /* ============================================================
-   WHETSTONE — TOKENS (Colors + Type + Spacing + Shadow + Border)
+   TIHOLE — TOKENS (Colors + Type + Spacing + Shadow + Border)
    ------------------------------------------------------------
    Brutalist, hard-edged identity for an OSS token-compression
    toolkit. Used for: marketing pages, README headers,

--- a/site/ds/tihole.css
+++ b/site/ds/tihole.css
@@ -1,5 +1,5 @@
 /* ============================================================
-   WHETSTONE — COMPONENT STYLESHEET
+   TIHOLE — COMPONENT STYLESHEET
    ------------------------------------------------------------
    Imports colors_and_type.css for tokens, then layers component
    classes on top. Single drop-in for marketing/docs surfaces.

--- a/site/page.css
+++ b/site/page.css
@@ -1,5 +1,5 @@
 /* ============================================================
-   WHETSTONE — MARKETING PAGE CHROME
+   TIHOLE — MARKETING PAGE CHROME
    Page-specific layout on top of tihole.css component layer
    ============================================================ */
 


### PR DESCRIPTION
Renames the three stale `WHETSTONE — …` header comments in the shipped site CSS (`site/ds/colors_and_type.css`, `site/ds/tihole.css`, `site/page.css`) to `TIHOLE`. Comment-only; no rendered output changes.

Last of the whetstone-scaffold branding leftovers flagged during the release audit.