### PR TITLE
feat(site): add umami click tracking to interactive elements

### DIFF
--- a/site/src/DocsLinks.jsx
+++ b/site/src/DocsLinks.jsx
@@ -18,7 +18,7 @@ function DocsLinks() {
       </div>
       <div className="docs-grid">
         {cards.map((c) => (
-          <a className="doc-card" key={c.title} href={c.href} target="_blank" rel="noreferrer">
+          <a className="doc-card" key={c.title} href={c.href} target="_blank" rel="noreferrer" data-umami-event={"docs-" + c.title.toLowerCase().replace(/\s+/g, "-")}>
             <span className="eyebrow">{c.eyebrow}</span>
             <span className="title">{c.title}</span>
             <span className="desc">{c.desc}</span>

--- a/site/src/FAQ.jsx
+++ b/site/src/FAQ.jsx
@@ -6,7 +6,7 @@
 function FAQItem({ n, q, children, open, onToggle }) {
   return (
     <div className={"faq-item" + (open ? " is-open" : "")}>
-      <button className="faq-q" aria-expanded={open} onClick={onToggle}>
+      <button className="faq-q" aria-expanded={open} onClick={onToggle} data-umami-event={"faq-" + String(n).padStart(2, "0")}>
         <span className="num">{String(n).padStart(2, "0")}</span>
         <span>{q}</span>
         <span className="glyph">{open ? "−" : "+"}</span>

--- a/site/src/Footer.jsx
+++ b/site/src/Footer.jsx
@@ -28,20 +28,20 @@ function Footer() {
           <div className="col">
             <h4>Project</h4>
             <ul>
-              <li><a href={repo} target="_blank" rel="noreferrer">GitHub</a></li>
-              <li><a href={repo + "/releases"} target="_blank" rel="noreferrer">Releases</a></li>
-              <li><a href={repo + "/issues"} target="_blank" rel="noreferrer">Issues</a></li>
-              <li><a href={repo + "/blob/main/CHANGELOG.md"} target="_blank" rel="noreferrer">Changelog</a></li>
+              <li><a href={repo} target="_blank" rel="noreferrer" data-umami-event="footer-github">GitHub</a></li>
+              <li><a href={repo + "/releases"} target="_blank" rel="noreferrer" data-umami-event="footer-releases">Releases</a></li>
+              <li><a href={repo + "/issues"} target="_blank" rel="noreferrer" data-umami-event="footer-issues">Issues</a></li>
+              <li><a href={repo + "/blob/main/CHANGELOG.md"} target="_blank" rel="noreferrer" data-umami-event="footer-changelog">Changelog</a></li>
             </ul>
           </div>
 
           <div className="col">
             <h4>Navigate</h4>
             <ul>
-              <li><a href="#screens">Screens</a></li>
-              <li><a href="#install">Install</a></li>
-              <li><a href="#keys">Keys</a></li>
-              <li><a href="#faq">FAQ</a></li>
+              <li><a href="#screens" data-umami-event="footer-nav-screens">Screens</a></li>
+              <li><a href="#install" data-umami-event="footer-nav-install">Install</a></li>
+              <li><a href="#keys" data-umami-event="footer-nav-keys">Keys</a></li>
+              <li><a href="#faq" data-umami-event="footer-nav-faq">FAQ</a></li>
             </ul>
           </div>
         </div>

--- a/site/src/Hero.jsx
+++ b/site/src/Hero.jsx
@@ -3,7 +3,7 @@
 // ============================================================
 // HERO — gradient wordmark, one-key value prop, live TUI preview
 // ============================================================
-function CopyChip({ cmd, prompt = "$" }) {
+function CopyChip({ cmd, prompt = "$", event = "copy-command" }) {
   const [copied, setCopied] = React.useState(false);
   const onCopy = () => {
     try {
@@ -20,6 +20,8 @@ function CopyChip({ cmd, prompt = "$" }) {
         className={"copy-btn" + (copied ? " is-copied" : "")}
         onClick={onCopy}
         aria-label="Copy install command"
+        data-umami-event={event}
+        data-umami-event-cmd={cmd}
       >
         {copied ? "COPIED" : "COPY"}
       </button>
@@ -103,8 +105,8 @@ function Hero() {
           </p>
 
           <div className="hero-cta">
-            <CopyChip cmd={goLine} />
-            <a className="ws-btn ws-btn--ghost" href="https://github.com/z19r/tihole" target="_blank" rel="noreferrer">
+            <CopyChip cmd={goLine} event="hero-copy-install" />
+            <a className="ws-btn ws-btn--ghost" href="https://github.com/z19r/tihole" target="_blank" rel="noreferrer" data-umami-event="hero-github-star">
               STAR ON GITHUB ↗
             </a>
           </div>

--- a/site/src/InstallTerminal.jsx
+++ b/site/src/InstallTerminal.jsx
@@ -27,7 +27,7 @@ function InstallTerminal() {
                 Prefer a prebuilt binary? Download it from the GitHub releases page.
               </div>
               <div style={{ marginTop: "var(--s-3)" }}>
-                <CopyChip cmd={goLine} />
+                <CopyChip cmd={goLine} event="install-copy-go" />
               </div>
             </div>
           </div>
@@ -53,7 +53,7 @@ function InstallTerminal() {
                 Press <code>?</code> any time for the full key map.
               </div>
               <div style={{ marginTop: "var(--s-3)" }}>
-                <CopyChip cmd="tihole" prompt="$" />
+                <CopyChip cmd="tihole" prompt="$" event="install-copy-run" />
               </div>
             </div>
           </div>

--- a/site/src/Nav.jsx
+++ b/site/src/Nav.jsx
@@ -37,7 +37,7 @@ function Nav({ theme, onToggleTheme }) {
 
   return (
     <nav className="ws-nav">
-      <a href="#top" className="ws-nav-mark" style={{
+      <a href="#top" className="ws-nav-mark" data-umami-event="nav-logo" style={{
         '--mark-bg': isLight ? '#F5F2E8' : '#110628',
         '--mark-fg': isLight ? '#07030E' : '#F5F2E8',
       }}>
@@ -47,17 +47,17 @@ function Nav({ theme, onToggleTheme }) {
 
       <div className="ws-nav-links">
         {sections.map((s) => (
-          <a key={s.id} href={'#' + s.id} className="ws-nav-link">{s.label}</a>
+          <a key={s.id} href={'#' + s.id} className="ws-nav-link" data-umami-event={"nav-" + s.id}>{s.label}</a>
         ))}
       </div>
 
       <div className="ws-nav-right">
         <span className="ws-badge ws-badge--acid"><span className="pulse"></span>v{window.TIHOLE_VERSION}</span>
-        <button className="theme-toggle" onClick={onToggleTheme} aria-label="Toggle theme">
+        <button className="theme-toggle" onClick={onToggleTheme} aria-label="Toggle theme" data-umami-event="theme-toggle">
           <span className="dot"></span>
           {isLight ? 'LIGHT' : 'NIGHT'}
         </button>
-        <a className="ws-btn ws-btn--sm ws-btn--ghost" href="https://github.com/z19r/tihole" target="_blank" rel="noreferrer">GITHUB ↗</a>
+        <a className="ws-btn ws-btn--sm ws-btn--ghost" href="https://github.com/z19r/tihole" target="_blank" rel="noreferrer" data-umami-event="nav-github">GITHUB ↗</a>
       </div>
     </nav>
   );

--- a/site/src/Releases.jsx
+++ b/site/src/Releases.jsx
@@ -176,6 +176,7 @@ function Releases() {
           href="https://github.com/z19r/tihole/blob/main/CHANGELOG.md"
           target="_blank"
           rel="noreferrer"
+          data-umami-event="releases-full-changelog"
         >
           FULL CHANGELOG ↗
         </a>

--- a/site/src/Screens.jsx
+++ b/site/src/Screens.jsx
@@ -75,6 +75,7 @@ function Screens() {
             aria-selected={active === t.id}
             className={"screens-tab" + (active === t.id ? " is-active" : "")}
             onClick={() => setActive(t.id)}
+            data-umami-event={"screens-tab-" + t.id}
           >
             <span className="ix">{String(i + 1).padStart(2, "0")}</span>
             {t.label}


### PR DESCRIPTION
## Summary

Adds Umami click-event tracking to every clickable element on the marketing site in `/site`. Umami is already loaded in `index.html`, so this uses the no-JS approach: a `data-umami-event` attribute that Umami auto-tracks on click. Attributes only — no behavior, styling, or accessibility changes.

Event names are consistent kebab-case, section-prefixed:

| Surface | Events |
|---|---|
| Nav | `nav-logo`, `nav-<section>` (×6), `theme-toggle`, `nav-github` |
| Hero | `hero-copy-install`, `hero-github-star` |
| Install | `install-copy-go`, `install-copy-run` |
| Screens | `screens-tab-<id>` (×4) |
| FAQ | `faq-01`…`faq-06` (unique per question) |
| Releases | `releases-full-changelog` |
| Docs | `docs-<slug>` (×4) |
| Footer | `footer-github/releases/issues/changelog`, `footer-nav-*` (×4) |

`CopyChip` gains an optional `event` prop (default `copy-command`) plus `data-umami-event-cmd` so the three copy buttons report distinct names and record which command was copied. Files with no clickable elements (Architecture, Keys, Numbers, App) are untouched.

## Test plan

- [x] All 12 JSX files transpile cleanly via `@babel/preset-react` (the site transpiles in-browser at runtime, so malformed JSX would white-screen the page).
- [x] Per-file `data-umami-event` coverage verified against the full clickable inventory; diff confirmed additions-only.
- [ ] Post-deploy: confirm events appear in the Umami dashboard with a few real clicks.