### PR TITLE
Prompt to raise the default hot-temperature threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.1] - 2026-08-24
 
+### Changed
+
+- Release tooling now pushes `main` and the release tag automatically as
+  part of `just release`.
+
 ## [1.2.0] - 2026-08-24
 
+### Changed
+
+- Dashboard and query log now poll four times a second for snappier
+  updates.
+
+### Fixed
+
+- Health gauge bars on the dashboard no longer wrap onto a second line.
+
 ## [1.1.0] - 2026-08-06
+
+### Added
+
+- Rich per-setting detail panel on the settings screen.
+
+### Fixed
+
+- Dashboard panels now size to their exact content width instead of
+  over- or under-sizing.
 
 ## [1.0.0-beta.1] - 2026-07-26
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,6 +30,7 @@ binaries and publish the GitHub release.
 | `.goreleaser.yaml` | Build matrix, archives, checksums, GitHub release. |
 | `.github/workflows/ci.yml` | Build + vet + test on push/PR. |
 | `.github/workflows/release.yml` | goreleaser on tag push `v*`. |
+| `scripts/backfill-changelog.sh` | Drafts and inserts entries for version headings that shipped with no changelog content, and re-syncs the site. |
 
 ## Local flow: `just release <level>`
 
@@ -38,6 +39,9 @@ Preconditions enforced by the recipe:
 - clean working tree
 - on the `main` branch
 - `VERSION` and `CHANGELOG.md` present
+- `## [Unreleased]` has at least one bullet — an empty `[Unreleased]`
+  aborts the release rather than shipping a version with no changelog
+  content (this is what let v1.1.0, v1.2.0, and v1.2.1 go out empty)
 
 Steps performed:
 
@@ -91,6 +95,25 @@ To regenerate the site changelog without cutting a release:
 ```text
 just changelog-sync
 ```
+
+## Recovering a missed changelog entry
+
+If a version was tagged with an empty section in `CHANGELOG.md` (and is
+therefore also missing from `site/src/changelog.js`, since
+`changelog-sync` skips sections with no bullets), draft and backfill it:
+
+```text
+scripts/backfill-changelog.sh            # dry run: prints a draft per
+                                          # empty version, built from the
+                                          # conventional-commit messages
+                                          # between that version's tag and
+                                          # the previous one
+scripts/backfill-changelog.sh --write    # insert the draft and re-run
+                                          # changelog-sync
+```
+
+Review the draft (or the diff after `--write`) before committing — it's a
+starting point assembled from raw commit subjects, not curated prose.
 
 ## Verifying goreleaser config locally
 

--- a/internal/theme/party.go
+++ b/internal/theme/party.go
@@ -1,0 +1,98 @@
+package theme
+
+import (
+	"image/color"
+	"math"
+	"time"
+)
+
+// NameParty is the hidden theme applied while the Konami-code easter egg is
+// active. It is deliberately absent from Names()/Builtin() — the only way in
+// is the cheat code.
+const NameParty = "party"
+
+// Party returns a fresh, wall-clock-driven rainbow theme: every token is a
+// full-saturation hue that sweeps over time, offset per token so the UI
+// reads as a wash of color rather than one flat tint. Call it again on every
+// animation tick (see the root model's party ticker) to advance the sweep;
+// Name stays "party" throughout, so Animated is set for callers that cache a
+// rebuild behind "has Theme.Name changed?".
+func Party() *Theme {
+	return &Theme{
+		Name:     NameParty,
+		Animated: true,
+		Surface:  wildDark(0, 0.4, 0.08),
+		Panel:    wildDark(210, 0.5, 0.14),
+		Text:     wildColor(0),
+		Subtle:   wildDark(60, 0.6, 0.75),
+		Accent:   wildColor(90),
+		Allow:    wildColor(150),
+		Block:    wildColor(210),
+		Warn:     wildColor(270),
+		Border:   wildColor(330),
+		Ramp:     wildRamp(),
+	}
+}
+
+// wildHue returns the current point on the color wheel for a token offset by
+// `offset` degrees from the base sweep, so simultaneously-rendered tokens
+// land at different hues instead of all flashing the same color together.
+func wildHue(offset int) float64 {
+	base := float64(time.Now().UnixMilli()/50) * 3
+	return base + float64(offset)
+}
+
+// wildColor is a full-saturation, full-value swatch: for foreground tokens
+// (text, borders, accents) that need to read as vivid against a dark
+// background.
+func wildColor(offset int) color.Color {
+	return hsvToRGB(wildHue(offset), 1, 1)
+}
+
+// wildDark is a desaturated, low-value swatch: for background tokens
+// (surface, panel) that need to stay dark enough for foreground text to read
+// while still drifting through the same sweep.
+func wildDark(offset int, saturation, value float64) color.Color {
+	return hsvToRGB(wildHue(offset), saturation, value)
+}
+
+// wildRamp builds the signature-gradient stops (boot banner, wordmark) as
+// evenly spaced points around the current sweep.
+func wildRamp() []color.Color {
+	const stops = 7
+	ramp := make([]color.Color, stops)
+	for i := range ramp {
+		ramp[i] = wildColor(i * (360 / stops))
+	}
+	return ramp
+}
+
+// hsvToRGB converts hue (degrees, wraps), saturation, and value (both
+// [0,1]) to an RGB color.
+func hsvToRGB(hue, saturation, value float64) color.Color {
+	h := math.Mod(math.Mod(hue, 360)+360, 360)
+	c := value * saturation
+	x := c * (1 - math.Abs(math.Mod(h/60, 2)-1))
+	m := value - c
+	var r, g, b float64
+	switch {
+	case h < 60:
+		r, g, b = c, x, 0
+	case h < 120:
+		r, g, b = x, c, 0
+	case h < 180:
+		r, g, b = 0, c, x
+	case h < 240:
+		r, g, b = 0, x, c
+	case h < 300:
+		r, g, b = x, 0, c
+	default:
+		r, g, b = c, 0, x
+	}
+	return color.RGBA{
+		R: uint8((r + m) * 255),
+		G: uint8((g + m) * 255),
+		B: uint8((b + m) * 255),
+		A: 255,
+	}
+}

--- a/internal/theme/party_test.go
+++ b/internal/theme/party_test.go
@@ -1,0 +1,72 @@
+package theme
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestPartyHasNonNilTokensAndName(t *testing.T) {
+	th := Party()
+
+	if th.Name != NameParty {
+		t.Errorf("expected name %q, got %q", NameParty, th.Name)
+	}
+	if !th.Animated {
+		t.Error("expected Party to be Animated so callers re-render every tick")
+	}
+	tokensNonNil(t, th)
+
+	if len(th.Ramp) < 2 {
+		t.Errorf(
+			"expected Party to define a multi-stop ramp, got %d stops",
+			len(th.Ramp),
+		)
+	}
+}
+
+func TestPartyIsNotABuiltin(t *testing.T) {
+	// Party is a hidden Konami-code easter egg, not a selectable theme: it
+	// must stay out of Names()/Builtin() so cycleTheme and the palette never
+	// surface it.
+	if _, ok := Builtin(NameParty); ok {
+		t.Error("expected Builtin(\"party\") to report false")
+	}
+	for _, name := range Names() {
+		if name == NameParty {
+			t.Error("expected Names() to omit \"party\"")
+		}
+	}
+}
+
+func TestHSVToRGBKnownHues(t *testing.T) {
+	tests := []struct {
+		name string
+		hue  float64
+		want color.RGBA
+	}{
+		{"red", 0, color.RGBA{255, 0, 0, 255}},
+		{"green", 120, color.RGBA{0, 255, 0, 255}},
+		{"blue", 240, color.RGBA{0, 0, 255, 255}},
+		{"wraps past 360", 480, color.RGBA{0, 255, 0, 255}},
+		{"wraps negative", -240, color.RGBA{0, 255, 0, 255}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hsvToRGB(tc.hue, 1, 1).(color.RGBA)
+			if got != tc.want {
+				t.Errorf("hsvToRGB(%v, 1, 1) = %+v, want %+v", tc.hue, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWildHueOffsetsSpreadTokens(t *testing.T) {
+	// Different offsets sampled at the same instant must land on different
+	// points of the wheel, or every "wild" token would flash the same color
+	// together instead of reading as a wash of color.
+	a := wildHue(0)
+	b := wildHue(90)
+	if a == b {
+		t.Error("expected distinct offsets to produce distinct hues")
+	}
+}

--- a/internal/theme/party_test.go
+++ b/internal/theme/party_test.go
@@ -54,7 +54,12 @@ func TestHSVToRGBKnownHues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := hsvToRGB(tc.hue, 1, 1).(color.RGBA)
 			if got != tc.want {
-				t.Errorf("hsvToRGB(%v, 1, 1) = %+v, want %+v", tc.hue, got, tc.want)
+				t.Errorf(
+					"hsvToRGB(%v, 1, 1) = %+v, want %+v",
+					tc.hue,
+					got,
+					tc.want,
+				)
 			}
 		})
 	}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -38,6 +38,13 @@ type Theme struct {
 	// not set it. The Gloss theme fills it with its pink→purple→acid→cyan ramp.
 	Ramp []color.Color
 
+	// Animated marks a theme whose tokens change on every call even though
+	// Name stays constant (Party is the only one today). Screens that cache
+	// a rebuild behind "has Theme.Name changed?" must also check this, or an
+	// animated theme's colors freeze at whatever they were on the first
+	// cached frame.
+	Animated bool
+
 	// adapt, when non-nil, lets a theme return a mode-specific variant from
 	// Adapt(isDark). Built-in themes are committed to a single mode and leave
 	// this nil (Adapt returns the receiver unchanged).

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -43,6 +43,11 @@ const (
 	// always-on top-bar pill reflects external changes (a toggle from the web
 	// UI, an expiring temporary-disable timer) without the user acting.
 	blockPollInterval = 10 * time.Second
+
+	// partyTickInterval drives the Konami-code rainbow theme's animation once
+	// active. Fast enough to read as smooth motion, matching the boot
+	// splash/spinner cadence rather than the multi-second data-poll ones.
+	partyTickInterval = 50 * time.Millisecond
 )
 
 // splashDoneMsg fires when the boot splash's timer elapses.
@@ -51,6 +56,10 @@ type splashDoneMsg struct{}
 // blockPollMsg is the recurring tick that drives a background blocking
 // re-fetch.
 type blockPollMsg struct{}
+
+// partyTickMsg is the recurring tick that advances the Konami-code rainbow
+// theme while it's active.
+type partyTickMsg struct{}
 
 // blockingResultMsg carries a fresh blocking status.
 type blockingResultMsg struct{ status pihole.BlockingStatus }
@@ -90,6 +99,13 @@ type AppModel struct {
 
 	block components.BlockState
 	err   string
+
+	// konami/party back the Konami-code easter egg: entering the sequence
+	// toggles a wall-clock-driven rainbow theme, restoring the prior theme on
+	// re-entry. See handleKey and the partyTickMsg case in Update.
+	konami    core.KonamiDetector
+	party     bool
+	prevTheme *theme.Theme
 }
 
 // New builds the root model from a validated config and an authenticated
@@ -248,6 +264,13 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case partyTickMsg:
+		if !m.party {
+			return m, nil
+		}
+		m.ctx.Theme = theme.Party()
+		return m, partyTickCmd()
+
 	case blockPollMsg:
 		// Re-fetch in the background and reschedule the next tick. The pill
 		// keeps
@@ -300,6 +323,8 @@ func (m *AppModel) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
 	// screen
 	// binds. Everything else is zone-scoped so screen keys are never ambushed.
 	switch {
+	case m.konami.Feed(msg.String()):
+		return m.toggleParty(), true
 	case key.Matches(msg, k.Quit):
 		return tea.Quit, true
 	case key.Matches(msg, k.Help):
@@ -533,6 +558,30 @@ func (m *AppModel) cycleTheme() tea.Cmd {
 		}
 	}
 	return themeCmd(names[(cur+1)%len(names)])
+}
+
+// toggleParty flips the Konami-code easter egg: on entry it stashes the
+// live theme and starts the rainbow ticker; on exit it restores what was
+// showing before, re-adapted in case light/dark detection changed while it
+// ran.
+func (m *AppModel) toggleParty() tea.Cmd {
+	m.party = !m.party
+	if m.party {
+		m.prevTheme = m.ctx.Theme
+		m.ctx.Theme = theme.Party()
+		return partyTickCmd()
+	}
+	m.ctx.Theme = m.prevTheme.Adapt(m.isDark)
+	m.prevTheme = nil
+	return nil
+}
+
+// partyTickCmd schedules the next rainbow-theme animation frame.
+func partyTickCmd() tea.Cmd {
+	return tea.Tick(
+		partyTickInterval,
+		func(time.Time) tea.Msg { return partyTickMsg{} },
+	)
 }
 
 // themeCmd resolves a theme by name and emits a SetThemeMsg (or an ErrorMsg).

--- a/internal/tui/core/konami.go
+++ b/internal/tui/core/konami.go
@@ -1,0 +1,38 @@
+package core
+
+// konamiSequence is the classic cheat code, matched against literal key
+// strings (arrow keys, not their vim h/j/k/l aliases) so vim-style
+// navigation never triggers it by accident.
+var konamiSequence = []string{
+	"up", "up", "down", "down",
+	"left", "right", "left", "right",
+	"b", "a", "enter",
+}
+
+// KonamiDetector recognizes the Konami code across a stream of key presses.
+// The zero value is ready to use.
+type KonamiDetector struct {
+	pos int
+}
+
+// Feed advances the detector by one key press (as returned by
+// tea.KeyPressMsg.String()) and reports whether the full sequence just
+// completed. It resets to the start after either a completed sequence or a
+// mismatched key, so it can be fed continuously without the caller
+// filtering input first.
+func (k *KonamiDetector) Feed(key string) bool {
+	if key == konamiSequence[k.pos] {
+		k.pos++
+		if k.pos == len(konamiSequence) {
+			k.pos = 0
+			return true
+		}
+		return false
+	}
+	if key == konamiSequence[0] {
+		k.pos = 1
+	} else {
+		k.pos = 0
+	}
+	return false
+}

--- a/internal/tui/core/konami_test.go
+++ b/internal/tui/core/konami_test.go
@@ -14,7 +14,9 @@ func feedAll(t *testing.T, keys ...string) bool {
 
 func TestKonamiDetectorFullSequenceCompletes(t *testing.T) {
 	if !feedAll(t, konamiSequence...) {
-		t.Error("expected the full sequence to report completion on the last key")
+		t.Error(
+			"expected the full sequence to report completion on the last key",
+		)
 	}
 }
 
@@ -57,7 +59,9 @@ func TestKonamiDetectorMismatchThatEqualsFirstKeyReloads(t *testing.T) {
 		done = d.Feed(k)
 	}
 	if !done {
-		t.Error("expected re-feeding from the second key onward to still complete")
+		t.Error(
+			"expected re-feeding from the second key onward to still complete",
+		)
 	}
 }
 
@@ -67,7 +71,9 @@ func TestKonamiDetectorIsReusableAfterCompletion(t *testing.T) {
 		d.Feed(k)
 	}
 	if !feedAll(t, konamiSequence...) {
-		t.Error("expected the detector to be triggerable again after completing once")
+		t.Error(
+			"expected the detector to be triggerable again after completing once",
+		)
 	}
 }
 

--- a/internal/tui/core/konami_test.go
+++ b/internal/tui/core/konami_test.go
@@ -1,0 +1,79 @@
+package core
+
+import "testing"
+
+func feedAll(t *testing.T, keys ...string) bool {
+	t.Helper()
+	var d KonamiDetector
+	var done bool
+	for _, k := range keys {
+		done = d.Feed(k)
+	}
+	return done
+}
+
+func TestKonamiDetectorFullSequenceCompletes(t *testing.T) {
+	if !feedAll(t, konamiSequence...) {
+		t.Error("expected the full sequence to report completion on the last key")
+	}
+}
+
+func TestKonamiDetectorOnlyFinalKeyReportsTrue(t *testing.T) {
+	var d KonamiDetector
+	for i, key := range konamiSequence {
+		got := d.Feed(key)
+		want := i == len(konamiSequence)-1
+		if got != want {
+			t.Errorf("Feed(%q) at position %d = %v, want %v", key, i, got, want)
+		}
+	}
+}
+
+func TestKonamiDetectorResetsOnMismatch(t *testing.T) {
+	var d KonamiDetector
+	d.Feed("up")
+	d.Feed("up")
+	if d.Feed("x") {
+		t.Fatal("mismatched key must never report completion")
+	}
+	// Having reset, the real sequence must still work from scratch.
+	if !feedAll(t, konamiSequence...) {
+		t.Error("expected detector to recover after a mismatch")
+	}
+}
+
+func TestKonamiDetectorMismatchThatEqualsFirstKeyReloads(t *testing.T) {
+	var d KonamiDetector
+	d.Feed("up")
+	d.Feed("up")
+	d.Feed("down")
+	// "up" isn't the expected fourth key ("down"), but it does equal the
+	// sequence's first key, so the detector should treat it as a fresh
+	// start (position 1) rather than resetting all the way to untyped.
+	d.Feed("up")
+	rest := konamiSequence[1:]
+	var done bool
+	for _, k := range rest {
+		done = d.Feed(k)
+	}
+	if !done {
+		t.Error("expected re-feeding from the second key onward to still complete")
+	}
+}
+
+func TestKonamiDetectorIsReusableAfterCompletion(t *testing.T) {
+	var d KonamiDetector
+	for _, k := range konamiSequence {
+		d.Feed(k)
+	}
+	if !feedAll(t, konamiSequence...) {
+		t.Error("expected the detector to be triggerable again after completing once")
+	}
+}
+
+func TestKonamiDetectorWrongKeyAtStartNeverCompletes(t *testing.T) {
+	var d KonamiDetector
+	if d.Feed("enter") {
+		t.Fatal("an unrelated first key must never complete the sequence")
+	}
+}

--- a/internal/tui/party_test.go
+++ b/internal/tui/party_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/z19r/tihole/internal/theme"
+)
+
+// konamiKeys returns the Konami code as the keyPress messages handleKey
+// expects, matching the literal arrow-key strings (not vim aliases).
+func konamiKeys() []tea.KeyPressMsg {
+	return []tea.KeyPressMsg{
+		keyPress("up", tea.KeyUp),
+		keyPress("up", tea.KeyUp),
+		keyPress("down", tea.KeyDown),
+		keyPress("down", tea.KeyDown),
+		keyPress("left", tea.KeyLeft),
+		keyPress("right", tea.KeyRight),
+		keyPress("left", tea.KeyLeft),
+		keyPress("right", tea.KeyRight),
+		keyPress("b", 'b'),
+		keyPress("a", 'a'),
+		keyPress("enter", tea.KeyEnter),
+	}
+}
+
+func TestKonamiCodeTogglesPartyMode(t *testing.T) {
+	m := sized(t, newTestModel(t), 120, 40)
+	original := m.ctx.Theme
+
+	var lastHandled bool
+	var lastCmd tea.Cmd
+	for _, k := range konamiKeys() {
+		lastCmd, lastHandled = m.handleKey(k)
+	}
+
+	if !lastHandled {
+		t.Fatal("expected the final Konami key to be handled")
+	}
+	if !m.party {
+		t.Fatal("expected party mode to be enabled after the full sequence")
+	}
+	if m.ctx.Theme.Name != theme.NameParty {
+		t.Errorf("expected theme %q, got %q", theme.NameParty, m.ctx.Theme.Name)
+	}
+	if !m.ctx.Theme.Animated {
+		t.Error("expected the party theme to be Animated")
+	}
+	if m.prevTheme != original {
+		t.Error("expected prevTheme to stash the theme active before party mode")
+	}
+	if lastCmd == nil {
+		t.Error("expected toggling party mode on to schedule the animation ticker")
+	}
+}
+
+func TestKonamiCodeAgainRestoresPreviousTheme(t *testing.T) {
+	m := sized(t, newTestModel(t), 120, 40)
+	original := m.ctx.Theme
+
+	for _, k := range konamiKeys() {
+		m.handleKey(k)
+	}
+	for _, k := range konamiKeys() {
+		m.handleKey(k)
+	}
+
+	if m.party {
+		t.Fatal("expected party mode to be disabled after a second full sequence")
+	}
+	if m.ctx.Theme.Name != original.Name {
+		t.Errorf("expected theme restored to %q, got %q", original.Name, m.ctx.Theme.Name)
+	}
+	if m.prevTheme != nil {
+		t.Error("expected prevTheme to be cleared once party mode ends")
+	}
+}
+
+func TestPartialKonamiSequenceDoesNotTriggerPartyMode(t *testing.T) {
+	m := sized(t, newTestModel(t), 120, 40)
+
+	keys := konamiKeys()
+	for _, k := range keys[:len(keys)-1] {
+		m.handleKey(k)
+	}
+
+	if m.party {
+		t.Fatal("expected an incomplete sequence to leave party mode off")
+	}
+}
+
+func TestWrongSequenceDoesNotTriggerPartyMode(t *testing.T) {
+	m := sized(t, newTestModel(t), 120, 40)
+
+	for _, k := range []tea.KeyPressMsg{
+		keyPress("down", tea.KeyDown),
+		keyPress("up", tea.KeyUp),
+		keyPress("left", tea.KeyLeft),
+		keyPress("right", tea.KeyRight),
+	} {
+		m.handleKey(k)
+	}
+
+	if m.party {
+		t.Fatal("expected a mismatched sequence to leave party mode off")
+	}
+}
+
+func TestPartyTickMsgIsNoopWhenNotPartying(t *testing.T) {
+	m := sized(t, newTestModel(t), 120, 40)
+	original := m.ctx.Theme
+
+	updated, cmd := m.Update(partyTickMsg{})
+	got := updated.(*AppModel)
+
+	if got.ctx.Theme != original {
+		t.Error("expected the theme to be untouched when party mode is off")
+	}
+	if cmd != nil {
+		t.Error("expected no rescheduled tick when party mode is off")
+	}
+}
+
+func TestPartyTickMsgAnimatesAndReschedulesWhilePartying(t *testing.T) {
+	m := sized(t, newTestModel(t), 120, 40)
+	for _, k := range konamiKeys() {
+		m.handleKey(k)
+	}
+
+	before := m.ctx.Theme
+	updated, cmd := m.Update(partyTickMsg{})
+	got := updated.(*AppModel)
+
+	if got.ctx.Theme == before {
+		t.Error("expected the tick to regenerate the theme instance")
+	}
+	if got.ctx.Theme.Name != theme.NameParty {
+		t.Errorf("expected theme to stay %q, got %q", theme.NameParty, got.ctx.Theme.Name)
+	}
+	if cmd == nil {
+		t.Error("expected the tick to reschedule itself while partying")
+	}
+}

--- a/internal/tui/party_test.go
+++ b/internal/tui/party_test.go
@@ -49,10 +49,14 @@ func TestKonamiCodeTogglesPartyMode(t *testing.T) {
 		t.Error("expected the party theme to be Animated")
 	}
 	if m.prevTheme != original {
-		t.Error("expected prevTheme to stash the theme active before party mode")
+		t.Error(
+			"expected prevTheme to stash the theme active before party mode",
+		)
 	}
 	if lastCmd == nil {
-		t.Error("expected toggling party mode on to schedule the animation ticker")
+		t.Error(
+			"expected toggling party mode on to schedule the animation ticker",
+		)
 	}
 }
 
@@ -68,10 +72,16 @@ func TestKonamiCodeAgainRestoresPreviousTheme(t *testing.T) {
 	}
 
 	if m.party {
-		t.Fatal("expected party mode to be disabled after a second full sequence")
+		t.Fatal(
+			"expected party mode to be disabled after a second full sequence",
+		)
 	}
 	if m.ctx.Theme.Name != original.Name {
-		t.Errorf("expected theme restored to %q, got %q", original.Name, m.ctx.Theme.Name)
+		t.Errorf(
+			"expected theme restored to %q, got %q",
+			original.Name,
+			m.ctx.Theme.Name,
+		)
 	}
 	if m.prevTheme != nil {
 		t.Error("expected prevTheme to be cleared once party mode ends")
@@ -137,7 +147,11 @@ func TestPartyTickMsgAnimatesAndReschedulesWhilePartying(t *testing.T) {
 		t.Error("expected the tick to regenerate the theme instance")
 	}
 	if got.ctx.Theme.Name != theme.NameParty {
-		t.Errorf("expected theme to stay %q, got %q", theme.NameParty, got.ctx.Theme.Name)
+		t.Errorf(
+			"expected theme to stay %q, got %q",
+			theme.NameParty,
+			got.ctx.Theme.Name,
+		)
 	}
 	if cmd == nil {
 		t.Error("expected the tick to reschedule itself while partying")

--- a/internal/tui/screens/dashboard/dashboard.go
+++ b/internal/tui/screens/dashboard/dashboard.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/z19r/tihole/internal/pihole"
 	"github.com/z19r/tihole/internal/theme"
+	"github.com/z19r/tihole/internal/tui/components"
 	"github.com/z19r/tihole/internal/tui/core"
 )
 
@@ -33,7 +34,24 @@ const (
 	// hot is amber, at/above hot is red.
 	healthWarnFrac = 0.60
 	healthHotFrac  = 0.85
+
+	// hotLimitDefault is Pi-hole's factory-default hot-temperature threshold
+	// (misc.temp.limit, °C). It's low enough that many SBCs trip it under
+	// normal load, so the dashboard offers to raise it once per session.
+	hotLimitDefault = 60.0
+	// hotLimitSuggested is the value offered in place of hotLimitDefault,
+	// closer to where these CPUs actually throttle.
+	hotLimitSuggested = 85.0
 )
+
+// hotTempPromptMessage explains why hotLimitDefault trips false "hot"
+// warnings and what raising it to hotLimitSuggested buys instead. Wrapped by
+// hand since components.ConfirmDialog doesn't wrap its body text.
+const hotTempPromptMessage = `Pi-hole's hot-temperature threshold is 60°C, but most
+single-board computers idle in the 45-60°C range and
+routinely reach 60-70°C under normal load — so 60°C
+trips false "hot" warnings on the health gauge. Raise
+it to 85°C, closer to where these CPUs actually throttle?`
 
 // tickMsg drives the poll loop. epoch is captured when the tick is scheduled so
 // stale ticks left over from a previous Focus are ignored.
@@ -84,6 +102,14 @@ type systemMsg struct {
 	msgErr   error
 }
 
+// hotLimitPatchMsg carries the result of raising the hot-temperature
+// threshold, tagged with the epoch so a reply from a since-blurred screen is
+// dropped.
+type hotLimitPatchMsg struct {
+	epoch int
+	err   error
+}
+
 // Model is the dashboard Screen.
 type Model struct {
 	ctx *core.AppContext
@@ -112,6 +138,12 @@ type Model struct {
 	system    pihole.SystemInfo
 	sensors   pihole.Sensors
 	messages  []pihole.DiagnosisMessage
+
+	// hotTempPrompt offers to raise hotLimitDefault to hotLimitSuggested; once
+	// shown (accepted or declined) hotTempPrompted latches so it doesn't nag
+	// again for the rest of the session.
+	hotTempPrompt   components.ConfirmDialog
+	hotTempPrompted bool
 
 	errSummary   string
 	errHistory   string
@@ -208,6 +240,7 @@ func (m *Model) applySystem(msg systemMsg) tea.Cmd {
 	if msg.senErr == nil {
 		m.sensors = msg.sensors
 	}
+	m.maybePromptHotLimit()
 	if msg.msgErr != nil {
 		m.errMessages = msg.msgErr.Error()
 	} else {
@@ -227,6 +260,60 @@ func (m *Model) applySystem(msg systemMsg) tea.Cmd {
 		)
 	}
 	return tea.Batch(cmds...)
+}
+
+// maybePromptHotLimit shows the hot-temperature-threshold suggestion the
+// first time the live sensors report Pi-hole's untouched factory default, so
+// a Celsius host with the stock 60°C limit is asked once per session whether
+// to raise it to hotLimitSuggested.
+func (m *Model) maybePromptHotLimit() {
+	if m.hotTempPrompted || !m.sensors.HasTemp || m.sensors.Unit != "C" ||
+		m.sensors.HotLimit != hotLimitDefault {
+		return
+	}
+	m.hotTempPrompted = true
+	m.hotTempPrompt = m.hotTempPrompt.Show(
+		"Raise hot-temperature threshold?",
+		hotTempPromptMessage,
+		false,
+	)
+}
+
+// CapturesInput reports true while the hot-temperature prompt is showing, so
+// the root delivers raw y/n keys instead of firing global shortcuts (see
+// core.InputCapturer). The dashboard is otherwise non-interactive.
+func (m *Model) CapturesInput() bool { return m.hotTempPrompt.Active }
+
+// handleHotTempKey interprets y/n on the hot-temperature-threshold prompt.
+func (m *Model) handleHotTempKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "enter":
+		m.hotTempPrompt = m.hotTempPrompt.Hide()
+		return m, m.patchHotLimit()
+	case "n", "esc":
+		m.hotTempPrompt = m.hotTempPrompt.Hide()
+	}
+	return m, nil
+}
+
+// patchHotLimit raises FTL's hot-temperature threshold (misc.temp.limit) to
+// hotLimitSuggested via PATCH /config.
+func (m *Model) patchHotLimit() tea.Cmd {
+	if m.ctx == nil || m.ctx.API == nil {
+		return nil
+	}
+	api := m.ctx.API
+	epoch := m.epoch
+	patch := map[string]any{
+		"misc": map[string]any{
+			"temp": map[string]any{"limit": hotLimitSuggested},
+		},
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+		defer cancel()
+		return hotLimitPatchMsg{epoch: epoch, err: api.PatchConfig(ctx, patch, false)}
+	}
 }
 
 // clampFrac constrains a gauge fraction to [0,1].
@@ -309,9 +396,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.fetchAll(), m.tick())
 
 	case tea.KeyPressMsg:
+		if m.hotTempPrompt.Active {
+			return m.handleHotTempKey(msg)
+		}
 		if m.focused && msg.String() == "r" {
 			return m, m.fetchAll()
 		}
+
+	case hotLimitPatchMsg:
+		if msg.epoch != m.epoch {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.errSystem = msg.err.Error()
+			return m, nil
+		}
+		return m, m.fetchAll()
 
 	case summaryMsg:
 		if msg.epoch != m.epoch {
@@ -537,6 +637,10 @@ func (m *Model) View() tea.View {
 			Render("Loading dashboard…")
 		body := lipgloss.Place(m.w, m.h, lipgloss.Center, lipgloss.Center, msg)
 		return tea.NewView(surface.Render(body))
+	}
+
+	if m.hotTempPrompt.Active {
+		return tea.NewView(surface.Render(m.hotTempPrompt.Render(th, m.w, m.h)))
 	}
 
 	sections := []string{

--- a/internal/tui/screens/dashboard/dashboard.go
+++ b/internal/tui/screens/dashboard/dashboard.go
@@ -47,11 +47,11 @@ const (
 // hotTempPromptMessage explains why hotLimitDefault trips false "hot"
 // warnings and what raising it to hotLimitSuggested buys instead. Wrapped by
 // hand since components.ConfirmDialog doesn't wrap its body text.
-const hotTempPromptMessage = `Pi-hole's hot-temperature threshold is 60°C, but most
-single-board computers idle in the 45-60°C range and
-routinely reach 60-70°C under normal load — so 60°C
-trips false "hot" warnings on the health gauge. Raise
-it to 85°C, closer to where these CPUs actually throttle?`
+const hotTempPromptMessage = `Pi-hole's hot-temperature threshold is
+60°C, but most single-board computers idle in the 45-60°C range
+and routinely reach 60-70°C under normal load — so 60°C trips
+false "hot" warnings on the health gauge. Raise it to 85°C,
+closer to where these CPUs actually throttle?`
 
 // tickMsg drives the poll loop. epoch is captured when the tick is scheduled so
 // stale ticks left over from a previous Focus are ignored.
@@ -312,7 +312,10 @@ func (m *Model) patchHotLimit() tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 		defer cancel()
-		return hotLimitPatchMsg{epoch: epoch, err: api.PatchConfig(ctx, patch, false)}
+		return hotLimitPatchMsg{
+			epoch: epoch,
+			err:   api.PatchConfig(ctx, patch, false),
+		}
 	}
 }
 

--- a/internal/tui/screens/dashboard/dashboard.go
+++ b/internal/tui/screens/dashboard/dashboard.go
@@ -217,7 +217,7 @@ func newHealthGauge(th *theme.Theme) progress.Model {
 // colors track the live palette. Current targets are preserved so values don't
 // jump.
 func (m *Model) syncBarTheme() {
-	if m.barTheme == m.ctx.Theme.Name {
+	if m.barTheme == m.ctx.Theme.Name && !m.ctx.Theme.Animated {
 		return
 	}
 	block, cpu, mem, temp := m.blockBar.Percent(), m.cpuBar.Percent(), m.memBar.Percent(), m.tempBar.Percent()

--- a/internal/tui/screens/dashboard/hottemp_test.go
+++ b/internal/tui/screens/dashboard/hottemp_test.go
@@ -12,14 +12,20 @@ import (
 func TestMaybePromptHotLimit_ShowsOnceAtFactoryDefault(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.sensors = pihole.Sensors{
+		HasTemp:  true,
+		Unit:     "C",
+		HotLimit: hotLimitDefault,
+	}
 
 	// Act
 	m.maybePromptHotLimit()
 
 	// Assert
 	if !m.hotTempPrompt.Active {
-		t.Fatal("expected the hot-temperature prompt to show at the factory default")
+		t.Fatal(
+			"expected the hot-temperature prompt to show at the factory default",
+		)
 	}
 	if !m.hotTempPrompted {
 		t.Fatal("expected hotTempPrompted to latch")
@@ -30,7 +36,9 @@ func TestMaybePromptHotLimit_ShowsOnceAtFactoryDefault(t *testing.T) {
 	m.hotTempPrompt = m.hotTempPrompt.Hide()
 	m.maybePromptHotLimit()
 	if m.hotTempPrompt.Active {
-		t.Fatal("expected the prompt to stay hidden once already shown this session")
+		t.Fatal(
+			"expected the prompt to stay hidden once already shown this session",
+		)
 	}
 }
 
@@ -55,7 +63,11 @@ func TestCapturesInput_TracksHotTempPrompt(t *testing.T) {
 	if m.CapturesInput() {
 		t.Fatal("should not capture input before the prompt is shown")
 	}
-	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.sensors = pihole.Sensors{
+		HasTemp:  true,
+		Unit:     "C",
+		HotLimit: hotLimitDefault,
+	}
 	m.maybePromptHotLimit()
 	if !m.CapturesInput() {
 		t.Fatal("should capture input while the prompt is active")
@@ -65,7 +77,11 @@ func TestCapturesInput_TracksHotTempPrompt(t *testing.T) {
 func TestHandleHotTempKey_DeclineHidesWithoutPatching(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.sensors = pihole.Sensors{
+		HasTemp:  true,
+		Unit:     "C",
+		HotLimit: hotLimitDefault,
+	}
 	m.maybePromptHotLimit()
 
 	// Act
@@ -83,7 +99,11 @@ func TestHandleHotTempKey_DeclineHidesWithoutPatching(t *testing.T) {
 func TestHandleHotTempKey_ConfirmHidesAndReturnsPatchCmd(t *testing.T) {
 	// Arrange
 	m := newTestModel()
-	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.sensors = pihole.Sensors{
+		HasTemp:  true,
+		Unit:     "C",
+		HotLimit: hotLimitDefault,
+	}
 	m.maybePromptHotLimit()
 
 	// Act
@@ -103,7 +123,11 @@ func TestUpdate_HotTempKeyTakesPrecedenceOverRefresh(t *testing.T) {
 	// intercept it instead since 'r' isn't a bound key on the dialog.
 	m := newTestModel()
 	m.Focus()
-	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.sensors = pihole.Sensors{
+		HasTemp:  true,
+		Unit:     "C",
+		HotLimit: hotLimitDefault,
+	}
 	m.maybePromptHotLimit()
 
 	// Act
@@ -111,7 +135,10 @@ func TestUpdate_HotTempKeyTakesPrecedenceOverRefresh(t *testing.T) {
 
 	// Assert
 	if !m.hotTempPrompt.Active {
-		t.Fatal("an unbound key should leave the prompt showing, not fall through to refresh")
+		t.Fatal(
+			"an unbound key should leave the prompt showing, " +
+				"not fall through to refresh",
+		)
 	}
 }
 
@@ -140,7 +167,10 @@ func TestUpdate_HotLimitPatchMsgErrorRecordedOnErrSystem(t *testing.T) {
 
 	// Assert
 	if m.errSystem != errBoom.Error() {
-		t.Fatalf("expected errSystem to record the patch failure, got %q", m.errSystem)
+		t.Fatalf(
+			"expected errSystem to record the patch failure, got %q",
+			m.errSystem,
+		)
 	}
 	if cmd != nil {
 		t.Fatal("a failed patch should not trigger a refetch")

--- a/internal/tui/screens/dashboard/hottemp_test.go
+++ b/internal/tui/screens/dashboard/hottemp_test.go
@@ -1,0 +1,163 @@
+package dashboard
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/z19r/tihole/internal/pihole"
+)
+
+func TestMaybePromptHotLimit_ShowsOnceAtFactoryDefault(t *testing.T) {
+	// Arrange
+	m := newTestModel()
+	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+
+	// Act
+	m.maybePromptHotLimit()
+
+	// Assert
+	if !m.hotTempPrompt.Active {
+		t.Fatal("expected the hot-temperature prompt to show at the factory default")
+	}
+	if !m.hotTempPrompted {
+		t.Fatal("expected hotTempPrompted to latch")
+	}
+
+	// Act again: a later poll (still at the default) shouldn't re-arm it after
+	// the user hides it.
+	m.hotTempPrompt = m.hotTempPrompt.Hide()
+	m.maybePromptHotLimit()
+	if m.hotTempPrompt.Active {
+		t.Fatal("expected the prompt to stay hidden once already shown this session")
+	}
+}
+
+func TestMaybePromptHotLimit_SkipsNonDefaultOrNonCelsius(t *testing.T) {
+	cases := []pihole.Sensors{
+		{HasTemp: true, Unit: "C", HotLimit: 75},
+		{HasTemp: true, Unit: "F", HotLimit: hotLimitDefault},
+		{HasTemp: false, Unit: "C", HotLimit: hotLimitDefault},
+	}
+	for _, sensors := range cases {
+		m := newTestModel()
+		m.sensors = sensors
+		m.maybePromptHotLimit()
+		if m.hotTempPrompt.Active {
+			t.Errorf("did not expect a prompt for sensors %+v", sensors)
+		}
+	}
+}
+
+func TestCapturesInput_TracksHotTempPrompt(t *testing.T) {
+	m := newTestModel()
+	if m.CapturesInput() {
+		t.Fatal("should not capture input before the prompt is shown")
+	}
+	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.maybePromptHotLimit()
+	if !m.CapturesInput() {
+		t.Fatal("should capture input while the prompt is active")
+	}
+}
+
+func TestHandleHotTempKey_DeclineHidesWithoutPatching(t *testing.T) {
+	// Arrange
+	m := newTestModel()
+	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.maybePromptHotLimit()
+
+	// Act
+	_, cmd := m.handleHotTempKey(tea.KeyPressMsg{Code: 'n', Text: "n"})
+
+	// Assert
+	if m.hotTempPrompt.Active {
+		t.Fatal("'n' should hide the prompt")
+	}
+	if cmd != nil {
+		t.Fatal("declining should not issue a patch command")
+	}
+}
+
+func TestHandleHotTempKey_ConfirmHidesAndReturnsPatchCmd(t *testing.T) {
+	// Arrange
+	m := newTestModel()
+	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.maybePromptHotLimit()
+
+	// Act
+	_, cmd := m.handleHotTempKey(tea.KeyPressMsg{Code: 'y', Text: "y"})
+
+	// Assert
+	if m.hotTempPrompt.Active {
+		t.Fatal("'y' should hide the prompt")
+	}
+	if cmd == nil {
+		t.Fatal("confirming should return a patch command")
+	}
+}
+
+func TestUpdate_HotTempKeyTakesPrecedenceOverRefresh(t *testing.T) {
+	// Arrange: focused, so 'r' would normally refresh; the active prompt must
+	// intercept it instead since 'r' isn't a bound key on the dialog.
+	m := newTestModel()
+	m.Focus()
+	m.sensors = pihole.Sensors{HasTemp: true, Unit: "C", HotLimit: hotLimitDefault}
+	m.maybePromptHotLimit()
+
+	// Act
+	m.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+
+	// Assert
+	if !m.hotTempPrompt.Active {
+		t.Fatal("an unbound key should leave the prompt showing, not fall through to refresh")
+	}
+}
+
+func TestUpdate_HotLimitPatchMsgDropsStaleEpoch(t *testing.T) {
+	// Arrange
+	m := newTestModel()
+	m.epoch = 5
+
+	// Act
+	_, cmd := m.Update(hotLimitPatchMsg{epoch: 4, err: nil})
+
+	// Assert
+	if cmd != nil {
+		t.Fatal("a reply from a superseded epoch should be dropped")
+	}
+}
+
+func TestUpdate_HotLimitPatchMsgErrorRecordedOnErrSystem(t *testing.T) {
+	// Arrange
+	m := newTestModel()
+	m.epoch = 2
+	errBoom := errors.New("boom")
+
+	// Act
+	_, cmd := m.Update(hotLimitPatchMsg{epoch: 2, err: errBoom})
+
+	// Assert
+	if m.errSystem != errBoom.Error() {
+		t.Fatalf("expected errSystem to record the patch failure, got %q", m.errSystem)
+	}
+	if cmd != nil {
+		t.Fatal("a failed patch should not trigger a refetch")
+	}
+}
+
+func TestUpdate_HotLimitPatchMsgSuccessRefetches(t *testing.T) {
+	// Arrange
+	m := newTestModel()
+	m.Focus()
+	m.epoch = 1
+
+	// Act
+	_, cmd := m.Update(hotLimitPatchMsg{epoch: 1, err: nil})
+
+	// Assert
+	if cmd == nil {
+		t.Fatal("a successful patch should refetch the dashboard data")
+	}
+}

--- a/justfile
+++ b/justfile
@@ -161,6 +161,18 @@ release LEVEL:
     if [[ "$BRANCH" != "main" ]]; then
         echo "Error: release must run from main (on $BRANCH)"; exit 1
     fi
+    # Refuse to promote an empty [Unreleased] section — this is what let
+    # v1.1.0, v1.2.0, and v1.2.1 ship with no changelog content.
+    UNRELEASED=$(awk '
+        /^## \[Unreleased\]/ { found=1; next }
+        found && /^## \[/ { exit }
+        found && /^- / { print; exit }
+    ' CHANGELOG.md)
+    if [[ -z "$UNRELEASED" ]]; then
+        echo "Error: [Unreleased] section in CHANGELOG.md is empty."
+        echo "Add changelog entries before releasing."
+        exit 1
+    fi
     # Release quality gate.
     go build ./...
     go vet ./...
@@ -220,6 +232,17 @@ prerelease:
     BRANCH=$(git rev-parse --abbrev-ref HEAD)
     if [[ "$BRANCH" != "main" ]]; then
         echo "Error: prerelease must run from main (on $BRANCH)"; exit 1
+    fi
+    # Refuse to promote an empty [Unreleased] section.
+    UNRELEASED=$(awk '
+        /^## \[Unreleased\]/ { found=1; next }
+        found && /^## \[/ { exit }
+        found && /^- / { print; exit }
+    ' CHANGELOG.md)
+    if [[ -z "$UNRELEASED" ]]; then
+        echo "Error: [Unreleased] section in CHANGELOG.md is empty."
+        echo "Add changelog entries before releasing."
+        exit 1
     fi
     # Release quality gate.
     go build ./...

--- a/scripts/backfill-changelog.sh
+++ b/scripts/backfill-changelog.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Finds released version headings in CHANGELOG.md that have no bullet
+# content (the bug that let v1.1.0, v1.2.0, and v1.2.1 ship empty), drafts
+# entries from the conventional-commit messages between that version's tag
+# and the previous one, and — with --write — inserts the draft and
+# regenerates site/src/changelog.js so both stay in sync.
+#
+# Usage:
+#   scripts/backfill-changelog.sh            # dry run: print the draft
+#   scripts/backfill-changelog.sh --write    # apply it and sync the site
+#
+# The draft is a starting point, not a final answer: review it (dry run
+# output, or the diff after --write) and trim/reword bullets by hand.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+WRITE=0
+if [[ "${1:-}" == "--write" ]]; then
+    WRITE=1
+elif [[ -n "${1:-}" ]]; then
+    echo "Usage: $0 [--write]" >&2
+    exit 1
+fi
+
+# Version headings in file order, newest first, excluding [Unreleased].
+mapfile -t VERSIONS < <(grep -oP '^## \[\K[^]]+(?=\] - )' CHANGELOG.md)
+
+section_is_empty() {
+    awk -v ver="$1" '
+        $0 == "## [" ver "]" || index($0, "## [" ver "] ") == 1 { found=1; next }
+        found && /^## \[/ { exit }
+        found && /^- / { exit 1 }
+        END { if (!found) exit 1 }
+    ' CHANGELOG.md
+}
+
+# Conventional-commit subject -> "Section|bullet text".
+classify_commit() {
+    local subject="$1" section body
+    case "$subject" in
+        feat*': '*) section="Added" ;;
+        fix*': '*) section="Fixed" ;;
+        perf*': '*|refactor*': '*) section="Changed" ;;
+        *) section="Changed" ;;
+    esac
+    body="${subject#*: }"
+    body="$(tr '[:lower:]' '[:upper:]' <<<"${body:0:1}")${body:1}"
+    [[ "$body" == *. ]] || body="${body}."
+    printf '%s|%s\n' "$section" "$body"
+}
+
+draft_for_version() {
+    local ver="$1" this_tag="v$1" prev_tag="$2"
+    local range
+    if git rev-parse -q --verify "refs/tags/$this_tag" >/dev/null; then
+        range="${prev_tag:+$prev_tag..}$this_tag"
+    else
+        range="${prev_tag:+$prev_tag..}HEAD"
+    fi
+
+    local -A bullets=()
+    local order=()
+    while IFS=$'\t' read -r subject; do
+        [[ "$subject" == release:\ * ]] && continue
+        [[ "$subject" == Merge\ * ]] && continue
+        local pair section body
+        pair="$(classify_commit "$subject")"
+        section="${pair%%|*}"
+        body="${pair#*|}"
+        if [[ -z "${bullets[$section]:-}" ]]; then
+            order+=("$section")
+        fi
+        bullets["$section"]+="- ${body}"$'\n'
+    done < <(git log --no-merges --reverse --pretty='%s' "$range" -- . 2>/dev/null || true)
+
+    [[ "${#order[@]}" -eq 0 ]] && return 1
+
+    echo "## [$ver]"
+    for section in Added Changed Fixed; do
+        [[ -n "${bullets[$section]:-}" ]] || continue
+        echo
+        echo "### $section"
+        echo
+        printf '%s' "${bullets[$section]}"
+    done
+}
+
+FOUND_EMPTY=0
+DRAFTS=()
+for i in "${!VERSIONS[@]}"; do
+    ver="${VERSIONS[$i]}"
+    [[ "$ver" == *-* ]] && continue # skip prereleases/betas
+    section_is_empty "$ver" || continue
+    FOUND_EMPTY=1
+
+    prev_tag=""
+    for ((j = i + 1; j < ${#VERSIONS[@]}; j++)); do
+        candidate="v${VERSIONS[$j]}"
+        if git rev-parse -q --verify "refs/tags/$candidate" >/dev/null; then
+            prev_tag="$candidate"
+            break
+        fi
+    done
+
+    draft="$(draft_for_version "$ver" "$prev_tag" || true)"
+    if [[ -z "$draft" ]]; then
+        echo "warn: no commits found to draft [$ver] from (skipping)" >&2
+        continue
+    fi
+    DRAFTS+=("$draft")
+done
+
+if [[ "$FOUND_EMPTY" -eq 0 ]]; then
+    echo "No empty version sections in CHANGELOG.md — nothing to backfill."
+    exit 0
+fi
+
+if [[ "$WRITE" -eq 0 ]]; then
+    printf '\n%s\n\n' "----- draft (review, then re-run with --write) -----"
+    for draft in "${DRAFTS[@]}"; do
+        printf '%s\n\n' "$draft"
+    done
+    exit 0
+fi
+
+for draft in "${DRAFTS[@]}"; do
+    ver="$(head -1 <<<"$draft" | sed -E 's/^## \[(.+)\]$/\1/')"
+    section_is_empty "$ver" || continue # re-check: may have been filled since
+    body="$(tail -n +3 <<<"$draft")" # drop the "## [ver]" line and its blank
+    line_no=$(grep -n "^## \[$ver\]" CHANGELOG.md | head -1 | cut -d: -f1)
+    insert_after=$((line_no + 1))
+    tmp="$(mktemp)"
+    printf '%s\n\n' "$body" >"$tmp"
+    sed -i "${insert_after}r ${tmp}" CHANGELOG.md
+    rm -f "$tmp"
+    echo "backfilled [$ver] in CHANGELOG.md"
+done
+
+go run ./cmd/tihole changelog-sync
+echo "Review the changes (git diff), then commit."

--- a/site/src/changelog.js
+++ b/site/src/changelog.js
@@ -2,6 +2,54 @@
 // Source of truth: repo-root CHANGELOG.md.
 window.TIHOLE_CHANGELOG = [
   {
+    "ver": "1.2.1",
+    "date": "2026-08-24",
+    "sections": [
+      {
+        "name": "changed",
+        "bullets": [
+          "Release tooling now pushes `main` and the release tag automatically as part of `just release`."
+        ]
+      }
+    ]
+  },
+  {
+    "ver": "1.2.0",
+    "date": "2026-08-24",
+    "sections": [
+      {
+        "name": "changed",
+        "bullets": [
+          "Dashboard and query log now poll four times a second for snappier updates."
+        ]
+      },
+      {
+        "name": "fixed",
+        "bullets": [
+          "Health gauge bars on the dashboard no longer wrap onto a second line."
+        ]
+      }
+    ]
+  },
+  {
+    "ver": "1.1.0",
+    "date": "2026-08-06",
+    "sections": [
+      {
+        "name": "added",
+        "bullets": [
+          "Rich per-setting detail panel on the settings screen."
+        ]
+      },
+      {
+        "name": "fixed",
+        "bullets": [
+          "Dashboard panels now size to their exact content width instead of over- or under-sizing."
+        ]
+      }
+    ]
+  },
+  {
     "ver": "1.0.0-beta.1",
     "date": "2026-07-26",
     "sections": [


### PR DESCRIPTION
## Summary
- Dashboard now offers a one-time modal to raise Pi-hole's factory-default 60C hot-temperature threshold to 85C, since most SBCs idle/run in the 45-70C range and trip false "hot" warnings at the default.
- `just release`/`just prerelease` now refuse to run when the `[Unreleased]` changelog section is empty, closing the gap that let v1.1.0, v1.2.0, and v1.2.1 ship with no changelog content.
- Added `scripts/backfill-changelog.sh` and used it to backfill the missing v1.1.0/v1.2.0/v1.2.1 changelog entries (and re-synced `site/src/changelog.js`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Manually confirm the modal appears/patches `misc.temp.limit` against a live Pi-hole instance reporting the 60C default